### PR TITLE
Replace CTEST_COMMAND with CMAKE_CTEST_COMMAND

### DIFF
--- a/cmake-modules/BuildBEAST.cmake
+++ b/cmake-modules/BuildBEAST.cmake
@@ -83,10 +83,9 @@ macro(build_BEAST install_prefix staging_prefix )
     INSTALL_DIR ${staging_prefix}/${install_prefix}
     TEST_BEFORE_INSTALL 0 #TODO: figure out how to run test on external project
   )
-  string(REPLACE cmake ctest CTEST_COMMAND "${CMAKE_COMMAND}")
   
   IF(BUILD_TESTING)
-    ADD_TEST(NAME TEST_BEAST COMMAND ${CTEST_COMMAND} --output-on-failure 
+    ADD_TEST(NAME TEST_BEAST COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/BEAST-build
     )
       

--- a/cmake-modules/BuildPatchMorphology.cmake
+++ b/cmake-modules/BuildPatchMorphology.cmake
@@ -78,10 +78,9 @@ macro(build_PatchMorphology install_prefix staging_prefix itk_dir)
     INSTALL_DIR ${staging_prefix}/${install_prefix}
     TEST_BEFORE_INSTALL 0 #TODO: figure out how to run test on external project
   )
-  string(REPLACE cmake ctest CTEST_COMMAND "${CMAKE_COMMAND}")
   
   IF(BUILD_TESTING)
-    ADD_TEST(NAME TEST_PATCH_MORPHOLOGY COMMAND ${CTEST_COMMAND} --output-on-failure 
+    ADD_TEST(NAME TEST_PATCH_MORPHOLOGY COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/patch_morphology-build 
     )
       


### PR DESCRIPTION
The custom CTEST_COMMAND was calculated with a string replace, which
would case errors if the string "cmake" appeared elsewhere in the path
(e.g. /opt/cmake/bin/cmake would be changed to the non-existent
/opt/ctest/bin/ctset).