### PR TITLE
Updated install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Here is a list of bundled packages:
 
 ### Installing from github, need CMake >= 3.1 
 <pre><code>
-  git clone --recursive https://github.com/BIC-MNI/minc-toolkit-v2.git minc-toolkit-v2
+  To get the latest supported version of minc-toolkit-v2 (1.9.17) 
+  git clone --recursive --branch release-1.9.17 git@github.com:BIC-MNI/minc-toolkit-v2.git minc-toolkit-v2
   cd minc-toolkit-v2
   mkdir build && cd build
   ccmake .. # Enter configuration details, recommend not to use any system-provided libraries that are included in minc-toolkit-v2
@@ -76,6 +77,10 @@ Following command will configure build system to build all the tools and install
 -DUSE_SYSTEM_ZLIB:BOOL=OFF 
 
 make && make install
+
+If you have installed minc-toolkit-v2 outside of the default installation ( i.e. changing DCMAKE_INSTALL_PREFIX:PATH within the build above). 
+source minc-toolkit-config.sh
+
 </pre></code>
 ## Dependencies
 


### PR DESCRIPTION
Updated the install instructions to ensure the correct version is installed and added "source minc-toolkit-config.sh"  which is required when installing outside of the default installed path as /opt/ is typically shared in many computer clusters.