### PR TITLE
cmake-modules/BuildGSL.cmake: unbreak GSL download

### DIFF
--- a/cmake-modules/BuildGSL.cmake
+++ b/cmake-modules/BuildGSL.cmake
@@ -10,7 +10,7 @@ macro(build_gsl install_prefix staging_prefix)
     SET(EXT_LDFLAGS   "-L${staging_prefix}/${install_prefix}/lib${LIB_SUFFIX} ${CMAKE_MODULE_LINKER_FLAGS} ${CMAKE_MODULE_LINKER_FLAGS_DEBUG}" )
   ENDIF()
 
-GET_PACKAGE("http://mirrors.ibiblio.org/gnu/ftp/gnu/gsl/gsl-2.4.tar.gz" "dba736f15404807834dc1c7b93e83b92" "gsl-2.4.tar.gz" GSL_PATH ) 
+GET_PACKAGE("http://mirrors.ibiblio.org/gnu/gsl/gsl-2.4.tar.gz" "dba736f15404807834dc1c7b93e83b92" "gsl-2.4.tar.gz" GSL_PATH )
 
 ExternalProject_Add(GSL
         SOURCE_DIR GSL


### PR DESCRIPTION
- ibiblio mirror dropped the ftp/ subdirectory
- seems like hardcoding a specific mirror is trouble
- needs port to master