### PR TITLE
Update BuildNIFTI.cmake to nifti_clib v3.0.0

### DIFF
--- a/cmake-modules/BuildNIFTI.cmake
+++ b/cmake-modules/BuildNIFTI.cmake
@@ -62,14 +62,13 @@ macro(build_nifti install_prefix staging_prefix)
   SET(NIFTI_CMAKE_CXX_FLAGS "-fPIC ${CMAKE_CXX_FLAGS} -I${ZLIB_INCLUDE_DIR}")
   SET(NIFTI_CMAKE_C_FLAGS   "-fPIC ${CMAKE_C_FLAGS} -I${ZLIB_INCLUDE_DIR}")
 
-  
-  GET_PACKAGE("http://downloads.sourceforge.net/project/niftilib/nifticlib/nifticlib_2_0_0/nifticlib-2.0.0.tar.gz" "425a711f8f92fb1e1f088cbc55bea53a" "nifticlib-2.0.0.tar.gz" NIFTILIB_PATH ) 
-  
+  GET_PACKAGE("https://github.com/NIFTI-Imaging/nifti_clib/archive/refs/tags/v3.0.0.tar.gz" "ee40068103775a181522166e435ee82d" "nifti_clib-3.0.0.tar.gz" NIFTILIB_PATH )
+
   ExternalProject_Add(NIFTI
     SOURCE_DIR NIFTI
     BINARY_DIR NIFTI-build
     URL "${NIFTILIB_PATH}"
-    URL_MD5 "425a711f8f92fb1e1f088cbc55bea53a"
+    URL_HASH SHA256=fe6cb1076974df01844f3f4dab1aa844953b3bc1d679126c652975158573d03d
     CMAKE_GENERATOR ${CMAKE_GEN}
     CMAKE_ARGS
             -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
@@ -77,7 +76,7 @@ macro(build_nifti install_prefix staging_prefix)
             -DCMAKE_SKIP_RPATH:BOOL=OFF
             -DCMAKE_SKIP_INSTALL_RPATH:BOOL=OFF
             -DMACOSX_RPATH:BOOL=ON
-            -DCMAKE_INSTALL_RPATH:PATH=${install_prefix}/lib${LIB_SUFFIX}
+            -DCMAKE_INSTALL_RPATH:PATH=${install_prefix}/${CMAKE_INSTALL_LIBDIR}
             -DCMAKE_INSTALL_PREFIX:PATH=${install_prefix}
             "-DCMAKE_CXX_FLAGS_RELEASE:STRING=${NIFTI_CMAKE_CXX_FLAGS_RELEASE}"
             "-DCMAKE_C_FLAGS_RELEASE:STRING=${NIFTI_CMAKE_C_FLAGS_RELEASE}"
@@ -92,16 +91,23 @@ macro(build_nifti install_prefix staging_prefix)
             -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
             -DZLIB_INCLUDE_DIR:PATH=${ZLIB_INCLUDE_DIR}
             -DZLIB_LIBRARY:FILEPATH=${ZLIB_LIBRARY}
+            -DGIT_REPO_VERSION:STRING=3.0.0
+            -DNIFTI_BUILD_APPLICATIONS:BOOL=OFF
+            -DNIFTI_BUILD_TESTING:BOOL=OFF
+            -DBUILD_TESTING:BOOL=OFF
+            -DUSE_NIFTI2_CODE:BOOL=OFF
+            -DUSE_NIFTICDF_CODE:BOOL=OFF
+            -DNIFTI_INSTALL_NO_DOCS:BOOL=ON
    
     INSTALL_COMMAND $(MAKE) install DESTDIR=${staging_prefix}
     INSTALL_DIR ${staging_prefix}/${install_prefix}
   )
 
-SET(NIFTI_LIBRARY     ${staging_prefix}/${install_prefix}/lib${LIB_SUFFIX}/libniftiio.a )
+SET(NIFTI_LIBRARY     ${staging_prefix}/${install_prefix}/${CMAKE_INSTALL_LIBDIR}/libniftiio.a )
 SET(NIFTI_INCLUDE_DIR ${staging_prefix}/${install_prefix}/include/nifti )
-SET(ZNZ_LIBRARY       ${staging_prefix}/${install_prefix}/lib${LIB_SUFFIX}/libznz.a )
+SET(ZNZ_LIBRARY       ${staging_prefix}/${install_prefix}/${CMAKE_INSTALL_LIBDIR}/libznz.a )
 SET(ZNZ_INCLUDE_DIR   ${staging_prefix}/${install_prefix}/include/nifti )
 SET(NIFTI_FOUND ON)
 
-endmacro(build_nifti)
+endmacro()
 


### PR DESCRIPTION
- Switch download from SourceForge (nifticlib 2.0.0) to GitHub (nifti_clib 3.0.0)
- Use SHA256 hash instead of MD5
- Add nifti_clib-specific CMake args to disable apps/tests/docs
- Use CMAKE_INSTALL_LIBDIR instead of hardcoded lib
- Modernize endmacro() call