### PR TITLE
Disable libarchive test suite in superbuild to fix duplicate test CMake Error

### DIFF
--- a/cmake-modules/BuildLibarchive.cmake
+++ b/cmake-modules/BuildLibarchive.cmake
@@ -79,6 +79,7 @@ macro(build_libarchive install_prefix staging_prefix)
         -DENABLE_GRZIP:BOOL=OFF
         -DENABLE_LZMA:BOOL=OFF
         -DENABLE_COMPRESSION:BOOL=OFF
+        -DENABLE_TEST:BOOL=OFF
         -DZLIB_INCLUDE_DIR:PATH=${ZLIB_INCLUDE_DIR}
         -DZLIB_LIBRARY:FILEPATH=${ZLIB_LIBRARY}
         ${CMAKE_EXTERNAL_PROJECT_ARGS}


### PR DESCRIPTION
libarchive 3.8.6's GENERATE_LIST_H macro can produce a stale list.h with duplicate DEFINE_TEST entries, causing CMake to fail. Tests are not needed for a dependency build.