### PR TITLE
Fix linking of dcm2mnc with libarchive during static linking

### DIFF
--- a/cmake-modules/BuildLibarchive.cmake
+++ b/cmake-modules/BuildLibarchive.cmake
@@ -77,6 +77,8 @@ macro(build_libarchive install_prefix staging_prefix)
         -DENABLE_LZ4:BOOL=OFF
         -DENABLE_BZip2:BOOL=OFF
         -DENABLE_GRZIP:BOOL=OFF
+        -DENABLE_ACL:BOOL=OFF
+        -DENABLE_LIBB2:BOOL=OFF
         -DENABLE_LZMA:BOOL=OFF
         -DENABLE_COMPRESSION:BOOL=OFF
         -DZLIB_INCLUDE_DIR:PATH=${ZLIB_INCLUDE_DIR}


### PR DESCRIPTION
Building minc-toolkit-v2 fails when linking dcm2mnc because libarchive.a (v3.8.6) has unresolved symbols
 two system libraries:

     1. blake2sp_* (blake2sp_init, blake2sp_update, blake2sp_final) - from libb2, used by RAR5 format support
     2. acl_* (acl_get_entry, acl_set_file, etc.) - from libacl, used by POSIX ACL support

Both ENABLE_LIBB2 and ENABLE_ACL default to ON in libarchive 3.8.6. At configure time, libarchive found the
system libraries (/usr/lib/libacl.so, libb2) and compiled code referencing them. But when dcm2mnc links
statically against libarchive.a, only libarchive.a and libz are on the link line
(minctools/conversion/CMakeLists.txt:64), so the external symbols are unresolved.


The alternative would be to add these libraries to the linking call, but I'm not sure we need/require them.

With the assistance of Opus 4.6 in high effort mode.

```
[ 20%] Linking C executable dcm2mnc
/usr/bin/ld: ../../external//usr/local/lib/libarchive.a(archive_read_support_format_rar5.c.o): in function `push_data_ready':
archive_read_support_format_rar5.c:(.text.push_data_ready+0xdb): undefined reference to `blake2sp_update'
/usr/bin/ld: ../../external//usr/local/lib/libarchive.a(archive_read_support_format_rar5.c.o): in function `push_data':
archive_read_support_format_rar5.c:(.text.push_data+0x1cc): undefined reference to `blake2sp_update'
/usr/bin/ld: archive_read_support_format_rar5.c:(.text.push_data+0x2ad): undefined reference to `blake2sp_update'
/usr/bin/ld: ../../external//usr/local/lib/libarchive.a(archive_read_support_format_rar5.c.o): in function `process_head_file':
archive_read_support_format_rar5.c:(.text.process_head_file+0xc39): undefined reference to `blake2sp_init'
/usr/bin/ld: ../../external//usr/local/lib/libarchive.a(archive_read_support_format_rar5.c.o): in function `do_unstore_file':
archive_read_support_format_rar5.c:(.text.do_unstore_file+0x17e): undefined reference to `blake2sp_update'
/usr/bin/ld: ../../external//usr/local/lib/libarchive.a(archive_read_support_format_rar5.c.o): in function `rar5_read_data':
archive_read_support_format_rar5.c:(.text.rar5_read_data+0x1ab): undefined reference to `blake2sp_final'
/usr/bin/ld: ../../external//usr/local/lib/libarchive.a(archive_read_support_format_rar5.c.o): in function `rar5_read_data_skip':
archive_read_support_format_rar5.c:(.text.rar5_read_data_skip+0x250): undefined reference to `blake2sp_final'
/usr/bin/ld: ../../external//usr/local/lib/libarchive.a(archive_disk_acl_linux.c.o): in function `translate_acl':
archive_disk_acl_linux.c:(.text.translate_acl+0x42): undefined reference to `acl_get_entry'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.translate_acl+0x7a): undefined reference to `acl_get_tag_type'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.translate_acl+0xb0): undefined reference to `acl_get_entry'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.translate_acl+0xeb): undefined reference to `acl_get_permset'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.translate_acl+0x10f): undefined reference to `acl_get_perm'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.translate_acl+0x157): undefined reference to `acl_get_entry'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.translate_acl+0x1a6): undefined reference to `acl_get_qualifier'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.translate_acl+0x1bd): undefined reference to `acl_free'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.translate_acl+0x1e6): undefined reference to `acl_get_qualifier'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.translate_acl+0x1fd): undefined reference to `acl_free'
/usr/bin/ld: ../../external//usr/local/lib/libarchive.a(archive_disk_acl_linux.c.o): in function `set_acl':
archive_disk_acl_linux.c:(.text.set_acl+0x95): undefined reference to `acl_init'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.set_acl+0x10a): undefined reference to `acl_create_entry'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.set_acl+0x143): undefined reference to `acl_set_tag_type'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.set_acl+0x15b): undefined reference to `acl_get_permset'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.set_acl+0x16d): undefined reference to `acl_clear_perms'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.set_acl+0x1a0): undefined reference to `acl_add_perm'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.set_acl+0x1dc): undefined reference to `acl_free'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.set_acl+0x23b): undefined reference to `acl_set_tag_type'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.set_acl+0x269): undefined reference to `acl_set_tag_type'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.set_acl+0x278): undefined reference to `acl_set_qualifier'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.set_acl+0x293): undefined reference to `acl_set_tag_type'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.set_acl+0x2c1): undefined reference to `acl_set_tag_type'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.set_acl+0x2d0): undefined reference to `acl_set_qualifier'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.set_acl+0x2eb): undefined reference to `acl_set_tag_type'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.set_acl+0x30b): undefined reference to `acl_add_perm'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.set_acl+0x32e): undefined reference to `acl_add_perm'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.set_acl+0x381): undefined reference to `acl_set_fd'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.set_acl+0x423): undefined reference to `acl_set_file'
/usr/bin/ld: ../../external//usr/local/lib/libarchive.a(archive_disk_acl_linux.c.o): in function `archive_read_disk_entry_setup_acls':
archive_disk_acl_linux.c:(.text.archive_read_disk_entry_setup_acls+0x3e): undefined reference to `acl_get_fd'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.archive_read_disk_entry_setup_acls+0x8e): undefined reference to `acl_get_file'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.archive_read_disk_entry_setup_acls+0xb4): undefined reference to `acl_free'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.archive_read_disk_entry_setup_acls+0x101): undefined reference to `acl_get_file'
/usr/bin/ld: archive_disk_acl_linux.c:(.text.archive_read_disk_entry_setup_acls+0x126): undefined reference to `acl_free'
collect2: error: ld returned 1 exit status
make[2]: *** [minctools/conversion/CMakeFiles/dcm2mnc.dir/build.make:238: minctools/conversion/dcm2mnc] Error 1
make[1]: *** [CMakeFiles/Makefile2:7262: minctools/conversion/CMakeFiles/dcm2mnc.dir/all] Error 2
make: *** [Makefile:166: all] Error 2
```