### PR TITLE
ITK: bump from v4.13.3 release to release-4.14 branch tip

### DIFF
--- a/cmake-modules/BuildITKv4.cmake
+++ b/cmake-modules/BuildITKv4.cmake
@@ -128,20 +128,20 @@ macro(build_itkv4 install_prefix staging_prefix minc_dir)
   message("HDF5_HL_CPP_LIBRARY=${HDF5_HL_CPP_LIBRARY}")
   message("HDF5_BIN_DIR=${HDF5_BIN_DIR}")
 
-  # Pinned to release-4.14 branch tip (2026-05-05). No v4.14.X release tag has
+  # Pinned to release-4.14 branch tip (2026-05-09). No v4.14.X release tag has
   # been cut yet; bump this SHA when upstream pushes a meaningful fix. The 4.14
   # branch carries fixes for modern GCC and CMake 4 that the prior 4.13.3
   # release tarball needs heavy patching to support.
   GET_PACKAGE(
-    "https://github.com/InsightSoftwareConsortium/ITK/archive/b31208a22862a7e2fe713c3a90cb6b9b307b4795.tar.gz"
-    "f5285b0c2129c00c2b67e1589cd0eb56"
-    "InsightToolkit-4.14-b31208a2.tar.gz"
+    "https://github.com/InsightSoftwareConsortium/ITK/archive/d72b44595a13ed45e8cdb1d9f5db236f2be3ce66.tar.gz"
+    "25eee1af4553c030c1a48868c1504aed"
+    "InsightToolkit-4.14-d72b4459.tar.gz"
     ITKv4_PATH)
 
 
   ExternalProject_Add(ITKv4
     URL "${ITKv4_PATH}"
-    URL_MD5 "f5285b0c2129c00c2b67e1589cd0eb56"
+    URL_MD5 "25eee1af4553c030c1a48868c1504aed"
     UPDATE_COMMAND ""
     SOURCE_DIR ITKv4
     BINARY_DIR ITKv4-build

--- a/cmake-modules/BuildITKv4.cmake
+++ b/cmake-modules/BuildITKv4.cmake
@@ -128,16 +128,23 @@ macro(build_itkv4 install_prefix staging_prefix minc_dir)
   message("HDF5_HL_CPP_LIBRARY=${HDF5_HL_CPP_LIBRARY}")
   message("HDF5_BIN_DIR=${HDF5_BIN_DIR}")
 
-  GET_PACKAGE("https://github.com/InsightSoftwareConsortium/ITK/releases/download/v4.13.3/InsightToolkit-4.13.3.tar.gz" "d1c10c8288b47577d718a71190444815" "InsightToolkit-4.13.3.tar.gz" ITKv4_PATH ) 
+  # Pinned to release-4.14 branch tip (2026-05-05). No v4.14.X release tag has
+  # been cut yet; bump this SHA when upstream pushes a meaningful fix. The 4.14
+  # branch carries fixes for modern GCC and CMake 4 that the prior 4.13.3
+  # release tarball needs heavy patching to support.
+  GET_PACKAGE(
+    "https://github.com/InsightSoftwareConsortium/ITK/archive/b31208a22862a7e2fe713c3a90cb6b9b307b4795.tar.gz"
+    "f5285b0c2129c00c2b67e1589cd0eb56"
+    "InsightToolkit-4.14-b31208a2.tar.gz"
+    ITKv4_PATH)
 
 
   ExternalProject_Add(ITKv4
     URL "${ITKv4_PATH}"
-    URL_MD5 "d1c10c8288b47577d718a71190444815"
+    URL_MD5 "f5285b0c2129c00c2b67e1589cd0eb56"
     UPDATE_COMMAND ""
     SOURCE_DIR ITKv4
     BINARY_DIR ITKv4-build
-    PATCH_COMMAND patch -p1 < ${CMAKE_CURRENT_LIST_DIR}/cmake-modules/ITK4.13.3-gcc11.X-gcc12.X.patch
     CMAKE_GENERATOR ${CMAKE_GEN}
     CMAKE_ARGS
         -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}

--- a/cmake-modules/PatchITKv4.cmake
+++ b/cmake-modules/PatchITKv4.cmake
@@ -1,5 +1,5 @@
 message("Running PatchITKv4")
-SET(ITK_VERSION "ITK-4.13")
+SET(ITK_VERSION "ITK-4.14")
 
 message("staging_prefix=${staging_prefix}")
 


### PR DESCRIPTION
Switches the vendored ITK source from the v4.13.3 release tarball (2018-09) to a pinned commit on the [InsightSoftwareConsortium/ITK release-4.14 branch](https://github.com/InsightSoftwareConsortium/ITK/tree/release-4.14) (`b31208a2`, 2026-05-05).

### Why

The 4.13.3 tarball needs progressively more patching to build under modern GCC and CMake. `cmake-modules/ITK4.13.3-gcc11.X-gcc12.X.patch` covers GCC 11/12 but doesn't cover GCC 13+. The release pipeline in #189 hit a new failure on Fedora 42 (GCC 15): K&R-style prototype errors in VNL's `spFactor.c` (`error: conflicting types for 'FindBiggestInColExclude'; have 'RealNumber(void)'`) that the 4.13.3 patches don't cover.

The release-4.14 branch carries upstream fixes for modern toolchains, including CMake 4 policy compatibility. Maintaining our own patch series for each new GCC release is unsustainable; switching to a maintained branch puts that work on upstream.

### Implementation

- URL switched from the GitHub releases tarball to a `github.com/.../archive/<sha>.tar.gz` source-archive URL. These are deterministic per commit; pinned via `URL_MD5`.
- `PATCH_COMMAND` removed: the 4.13.3 GCC patch doesn't apply cleanly to 4.14 source and shouldn't be needed (release-4.14 has the equivalent fixes upstream).
- No `v4.14.X` release tag has been cut yet; once one ships, this should switch back to a release tarball URL for stability.
- The legacy patch files (`cmake-modules/ITK4.13.X-*.patch`) are left in the tree for now and can be cleaned up in a follow-up once 4.14 is proven across the CI matrix.

### Risk

ANTs/C3D/Elastix submodules target ITK 4. ABI/API differences between 4.13 and 4.14 are minimal but not zero; full superbuild needs to be exercised in CI. The release pipeline (#189) provides this exercise across Ubuntu 22.04/24.04/26.04, Debian 11/12/13, Fedora 42/43/44, and macOS — once #189 lands, this PR's CI run will surface any compat issues.