### PR TITLE
ITKv4: build C sources with -std=gnu17 for C23 compilers

### DIFF
--- a/cmake-modules/BuildITKv4.cmake
+++ b/cmake-modules/BuildITKv4.cmake
@@ -18,6 +18,15 @@ macro(build_itkv4 install_prefix staging_prefix minc_dir)
   LIST(APPEND EXT_CMAKE_CXX_FLAGS -D_XOPEN_SOURCE=600)
   ENDIF(NOT APPLE)
 
+  # GCC 15+ defaults to C23, where an empty () prototype means (void) rather
+  # than K&R unspecified-args. VXL's bundled netlib (v3p/netlib/sparse/spFactor.c)
+  # is vintage K&R C that declares functions with () and calls them with args,
+  # which now errors ("too many arguments to function ... expected 0").
+  # Pin ITK's C compilation to gnu17 so () keeps unspecified-args semantics.
+  # Use string concatenation (not LIST(APPEND)) so the flag stays part of the
+  # CMAKE_C_FLAGS value rather than becoming a separate ;-separated cmake arg.
+  SET(EXT_CMAKE_C_FLAGS "${EXT_CMAKE_C_FLAGS} -std=gnu17")
+
 
   set(CMAKE_EXTERNAL_PROJECT_ARGS
         -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}


### PR DESCRIPTION
## Summary

Pins ITK's C compilation to `gnu17` so the build survives C23-default compilers (GCC 15+).

## Problem

GCC 15+ (Fedora 42/43/44; GCC 16 locally) defaults to C23, where an empty `()` prototype means `(void)` rather than K&R unspecified-args. VXL's bundled netlib (`v3p/netlib/sparse/spFactor.c`) is vintage K&R C — it declares `FindBiggestInColExclude` / `FindLargestInCol` with `()` and calls them with arguments:

```
error: conflicting types for 'FindBiggestInColExclude'; have 'RealNumber(void)'
error: too many arguments to function 'FindBiggestInColExclude'; expected 0, have 3
```

The `release-4.14` branch does not patch this file.

## Fix

Append `-std=gnu17` to `EXT_CMAKE_C_FLAGS` (ITK's `CMAKE_C_FLAGS`) so `()` keeps unspecified-args semantics. C-only — ITK's C++ already compiles cleanly.

Concatenated into the flags **string** rather than `LIST(APPEND)`ed, so it stays part of the `CMAKE_C_FLAGS` value instead of being split off as a separate `;`-separated cmake argument (which yields `CMake Error: Unknown argument -std=gnu17`).

## Validation

Built locally under **GCC 16.1 / CMake 4.3**: ITKv4 configures, compiles `spFactor.c`, and installs cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)