### PR TITLE
PatchElastix: set CMP0033/CMP0007 to NEW for CMake 4.x

### DIFF
--- a/cmake-modules/PatchElastix.cmake
+++ b/cmake-modules/PatchElastix.cmake
@@ -21,5 +21,17 @@ string(REPLACE
   "# export_library_dependencies removed (CMP0033, CMake >= 3.28)"
   CONTENT "${CONTENT}")
 
+# 3. CMake 4.x no longer supports setting these policies to OLD. Use NEW:
+#    CMP0033 NEW is safe (export_library_dependencies already removed above),
+#    and CMP0007 defaults to NEW anyway given cmake_minimum_required(3.10).
+string(REPLACE
+  "cmake_policy( SET CMP0033 OLD )"
+  "cmake_policy( SET CMP0033 NEW )"
+  CONTENT "${CONTENT}")
+string(REPLACE
+  "cmake_policy( SET CMP0007 OLD )"
+  "cmake_policy( SET CMP0007 NEW )"
+  CONTENT "${CONTENT}")
+
 file(WRITE "${CMAKELISTS}" "${CONTENT}")
 message(STATUS "Patched Elastix CMakeLists.txt for CMake 3.28+ compatibility")


### PR DESCRIPTION
Elastix's `CMakeLists.txt` sets `CMP0033` and `CMP0007` to `OLD`; CMake 4.x removed OLD-behavior support for both, making them hard configure errors (`Policy CMP0033 may not be set to OLD behavior...`), breaking Ubuntu 26.04 resolute and other CMake-4 distros.

Extend `PatchElastix.cmake` to rewrite both to `NEW`: CMP0033 NEW is safe (the patch already strips `export_library_dependencies`), and CMP0007 defaults to NEW anyway under `cmake_minimum_required(3.10)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)