### PR TITLE
HDF5: update 1.10.6 -> 1.10.11

### DIFF
--- a/cmake-modules/BuildHDF5.cmake
+++ b/cmake-modules/BuildHDF5.cmake
@@ -62,11 +62,11 @@ macro(build_hdf5 install_prefix staging_prefix)
   SET(HDF_CMAKE_CXX_FLAGS "-fPIC ${CMAKE_CXX_FLAGS}")
   SET(HDF_CMAKE_C_FLAGS   "-fPIC ${CMAKE_C_FLAGS}")
 
-  GET_PACKAGE("https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.6/src/hdf5-1.10.6.tar.bz2" "03095102a6118c32a75a9b9b40be66f2" "hdf5-1.10.6.tar.bz2" HDF5_PATH )
+  GET_PACKAGE("https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.11/src/hdf5-1.10.11.tar.bz2" "b60f44a9210770794fb9a2949bfb9587" "hdf5-1.10.11.tar.bz2" HDF5_PATH )
 
 ExternalProject_Add(HDF5
   URL "${HDF5_PATH}"
-  URL_MD5 "03095102a6118c32a75a9b9b40be66f2"
+  URL_MD5 "b60f44a9210770794fb9a2949bfb9587"
   SOURCE_DIR HDF5
   BINARY_DIR HDF5-build
   CMAKE_GENERATOR ${CMAKE_GEN}


### PR DESCRIPTION
`hdf5-1.10.6` fails to build on current macOS toolchains (Xcode 16.x) — the `libhdf5` link is missing the generated `_H5libhdf5_settings` symbol. Update to **1.10.11**, the last 1.10.x release (same API/ABI, so ITK 4.14 and the rest of the toolkit stay compatible), which builds cleanly on modern compilers.

md5 `b60f44a9210770794fb9a2949bfb9587` (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)