### PR TITLE
libarchive: disable iconv (macOS undefined _iconv)

### DIFF
--- a/cmake-modules/BuildLibarchive.cmake
+++ b/cmake-modules/BuildLibarchive.cmake
@@ -82,6 +82,10 @@ macro(build_libarchive install_prefix staging_prefix)
         -DENABLE_LZMA:BOOL=OFF
         -DENABLE_COMPRESSION:BOOL=OFF
         -DENABLE_TEST:BOOL=OFF
+        # libarchive autodetects libiconv on macOS and pulls in _iconv symbols
+        # that downstream consumers (ITK's link) don't resolve. We don't need
+        # charset conversion, so disable it.
+        -DENABLE_ICONV:BOOL=OFF
         -DZLIB_INCLUDE_DIR:PATH=${ZLIB_INCLUDE_DIR}
         -DZLIB_LIBRARY:FILEPATH=${ZLIB_LIBRARY}
         ${CMAKE_EXTERNAL_PROJECT_ARGS}


### PR DESCRIPTION
On macOS, libarchive autodetects libiconv and references `_iconv`/`_iconv_close` from `archive_string.c`. Downstream consumers (ITK's link) link libarchive but not libiconv, so the link fails with `Undefined symbols: _iconv ...`. The toolkit doesn't use charset conversion — disable `ENABLE_ICONV`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)