### PR TITLE
Port two build fixes from develop-1.9.18 (libarchive iconv, LIBLBFGS Debug suffix)

### DIFF
--- a/cmake-modules/BuildLIBLBFGS.cmake
+++ b/cmake-modules/BuildLIBLBFGS.cmake
@@ -70,7 +70,11 @@ macro(build_liblbfgs install_prefix staging_prefix)
     INSTALL_DIR ${staging_prefix}/${install_prefix}
   )
   
-SET(LIBLBFGS_LIB_SUFFIX ".a")
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  SET(LIBLBFGS_LIB_SUFFIX "d.a")
+else()
+  SET(LIBLBFGS_LIB_SUFFIX ".a")
+endif()
 
 SET(LIBLBFGS_INCLUDE_DIR  ${staging_prefix}/${install_prefix}/include )
 SET(LIBLBFGS_LIBRARY_DIR  ${staging_prefix}/${install_prefix}/lib${LIB_SUFFIX}/ )

--- a/cmake-modules/BuildLibarchive.cmake
+++ b/cmake-modules/BuildLibarchive.cmake
@@ -82,6 +82,10 @@ macro(build_libarchive install_prefix staging_prefix)
         -DENABLE_LZMA:BOOL=OFF
         -DENABLE_COMPRESSION:BOOL=OFF
         -DENABLE_TEST:BOOL=OFF
+        # libarchive autodetects libiconv on macOS and pulls in _iconv symbols
+        # that downstream consumers (ITK's link) don't resolve. We don't need
+        # charset conversion, so disable it.
+        -DENABLE_ICONV:BOOL=OFF
         -DZLIB_INCLUDE_DIR:PATH=${ZLIB_INCLUDE_DIR}
         -DZLIB_LIBRARY:FILEPATH=${ZLIB_LIBRARY}
         ${CMAKE_EXTERNAL_PROJECT_ARGS}


### PR DESCRIPTION
While reconciling develop-1.9.18 with develop-1.9.19-ITKv5.4, I found the ITKv5.4 branch is otherwise well-synced with 1.9.18 (config-mode HDF5, GLFW-on-macOS, PCRE drop, ImageMagick removal, zlib-ng, FFTW arm64 guard, etc. all already ported). Two small, ITK-version-independent build fixes were missed by the sync:

1. **`BuildLibarchive.cmake`** — `-DENABLE_ICONV:BOOL=OFF`. libarchive autodetects libiconv on macOS and pulls in `_iconv` symbols that ITK's downstream link does not resolve. We don't need charset conversion. (From 1.9.18 "libarchive: disable iconv".)

2. **`BuildLIBLBFGS.cmake`** — use the `d.a` library suffix for Debug builds. liblbfgs installs its static archive as `liblbfgsd.a` in Debug, so `LIBLBFGS_LIBRARY` must reflect that (was hardcoded to `.a`, breaking Debug builds). (From 1.9.18 "BuildLIBLBFGS: use debug library suffix (d.a)".)

Both hunks are byte-identical to their develop-1.9.18 counterparts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189nbY2nSfCzYCDC2gg5KKb