### PR TITLE
C3D: skip GNU-ld --start-group patch on macOS (fixes ld64 link)

### DIFF
--- a/cmake-modules/PatchC3D.cmake
+++ b/cmake-modules/PatchC3D.cmake
@@ -62,13 +62,21 @@ endif()
 # ("missing --end-group; added as last command line option"), so every
 # archive -- including whatever CMake's closure appends after our explicit
 # list -- ends up inside the group and gets rescanned until symbols resolve.
-set(_top2 "${SOURCE_DIR}/CMakeLists.txt")
-file(READ "${_top2}" _fc)
-string(REPLACE
-  "LINK_LIBRARIES(\n  cnd_driver cnd_adapters"
-  "LINK_LIBRARIES(\n  -Wl,--start-group cnd_driver cnd_adapters"
-  _fc2 "${_fc}")
-if(NOT _fc STREQUAL _fc2)
-  file(WRITE "${_top2}" "${_fc2}")
-  message(STATUS "Patched C3D: open unclosed -Wl,--start-group so ld rescans the whole link line")
+#
+# GNU ld / gold / lld ONLY. Apple's ld64 (macOS) rescans archives by default
+# (see the cnd_driver note above -- it never hits this problem in the first
+# place) and rejects the flag outright: "ld: unknown options: --start-group",
+# which broke every macOS C3D link. So skip the injection on Darwin hosts.
+# (The patch host is the build host here; the superbuild never cross-compiles.)
+if(NOT CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
+  set(_top2 "${SOURCE_DIR}/CMakeLists.txt")
+  file(READ "${_top2}" _fc)
+  string(REPLACE
+    "LINK_LIBRARIES(\n  cnd_driver cnd_adapters"
+    "LINK_LIBRARIES(\n  -Wl,--start-group cnd_driver cnd_adapters"
+    _fc2 "${_fc}")
+  if(NOT _fc STREQUAL _fc2)
+    file(WRITE "${_top2}" "${_fc2}")
+    message(STATUS "Patched C3D: open unclosed -Wl,--start-group so ld rescans the whole link line")
+  endif()
 endif()


### PR DESCRIPTION
## Problem

`736184a` ("C3D: fix second single-pass-link bug (fftw3f_threads vs fftw3f)") injects an unclosed `-Wl,--start-group` into Convert3D's `LINK_LIBRARIES()` via `PatchC3D.cmake`, so GNU ld rescans the whole link line to resolve the `fftw3f_threads` → `fftw3f` circular reference.

`--start-group` is a GNU ld / gold / lld feature. **Apple's `ld64` rejects it outright** and fails every macOS `c3d` link:

```
ld: unknown options: --start-group --start-group
clang++: error: linker command failed with exit code 1
make[5]: *** [c3d] Error 1
```

This wasn't caught on `develop-1.9.18` because that branch has no macOS CI; it surfaced on the release-pipeline macOS jobs (macos-14/15, full variant).

## Fix

macOS `ld64` rescans archives by default, so it never hits the circular-reference problem the flag solves — the first C3D fix's own comment already notes this. Guard the injection to non-Darwin hosts only:

```cmake
if(NOT CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
  ... inject -Wl,--start-group ...
endif()
```

`CMAKE_HOST_SYSTEM_NAME` is the only reliable platform signal in `cmake -P` script mode (`APPLE` and `CMAKE_HOST_APPLE` are both empty there). The platform-agnostic `cnd_driver`/`cnd_adapters` reorder (the first fix) still applies on every toolchain.

## Verification

- `cmake -P` simulation: `-Wl,--start-group` injected on Linux, skipped on Darwin.
- Full CI matrix green — including `macos (full)` and `macos (minimal)` on macos-14/15 (release-pipeline run 30020529204).

🤖 Generated with [Claude Code](https://claude.com/claude-code)