### PR TITLE
CMake: add source tarball CPack configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -694,6 +694,22 @@ INCLUDE(DebianPackageAddons)
 # setup additional variables for making RPM package
 INCLUDE(RPMPackageAddons)
 
+# Source tarball generation: `cpack --config CPackSourceConfig.cmake -G TGZ`
+SET(CPACK_SOURCE_GENERATOR "TGZ")
+SET(CPACK_SOURCE_PACKAGE_FILE_NAME "minc-toolkit-v2-${MINC_TOOLKIT_VERSION_FULL}-src")
+SET(CPACK_SOURCE_IGNORE_FILES
+    "/\\.git/"
+    "/\\.github/"
+    "/minc-build.*/"
+    "/build/"
+    "\\.gitignore$"
+    "\\.tar\\.gz$"
+    "\\.deb$"
+    "\\.rpm$"
+    "\\.pkg$"
+    "/\\.vscode/"
+    "/\\.idea/")
+
 
 # according to http://www.cmake.org/pipermail/cmake/2011-November/047137.html it's better to put this in the end
 INCLUDE(CPack)


### PR DESCRIPTION
Configure CPACK_SOURCE_GENERATOR / FILE_NAME and CPACK_SOURCE_IGNORE_FILES
so `cpack --config CPackSourceConfig.cmake -G TGZ` produces a clean
source package (excluding .git, build trees, and prior artifacts) for
the release pipeline.

---
Independent slice of #189 — one concern, mergeable against `develop-1.9.18` in any order (all 10 slices touch disjoint files/line-regions). #189 stays open until these land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)