### PR TITLE
GSL/FreeType/libpng: CPPFLAGS must not carry the C++ -std (macOS clang)

### DIFF
--- a/cmake-modules/BuildGSL.cmake
+++ b/cmake-modules/BuildGSL.cmake
@@ -20,7 +20,7 @@ ExternalProject_Add(GSL
         INSTALL_DIR     "${CMAKE_BINARY_DIR}/external"
         BUILD_COMMAND   $(MAKE) -s V=0
         INSTALL_COMMAND $(MAKE) -s V=0 DESTDIR=${CMAKE_BINARY_DIR}/external install
-        CONFIGURE_COMMAND  ./configure --enable-silent-rules --silent  --prefix=${install_prefix} --libdir=${install_prefix}/lib${LIB_SUFFIX} --with-pic --disable-shared --enable-static CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} "CPPFLAGS=${EXT_CXX_FLAGS}"  "CXXFLAGS=${EXT_CXX_FLAGS}" "CFLAGS=${EXT_C_FLAGS}" "LDFLAGS=${EXT_LDFLAGS}"
+        CONFIGURE_COMMAND  ./configure --enable-silent-rules --silent  --prefix=${install_prefix} --libdir=${install_prefix}/lib${LIB_SUFFIX} --with-pic --disable-shared --enable-static CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} "CPPFLAGS=${EXT_C_FLAGS}"  "CXXFLAGS=${EXT_CXX_FLAGS}" "CFLAGS=${EXT_C_FLAGS}" "LDFLAGS=${EXT_LDFLAGS}"
 #        INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/external
       )
 


### PR DESCRIPTION
These pure-C autotools deps passed CPPFLAGS=${EXT_CXX_FLAGS}; once the C++
cap added -std=gnu++17 that landed on C compiles, and clang rejects a C++
-std for C ('not allowed with C') -> 'C compiler cannot create
executables'. Use ${EXT_C_FLAGS} for CPPFLAGS.

---
Independent slice of #189 — one concern, mergeable against `develop-1.9.18` in any order (all 10 slices touch disjoint files/line-regions). #189 stays open until these land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)