### PR TITLE
CMake: default to the GLFW windowing backend (MT_USE_GLFW=ON)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,9 +138,10 @@ OPTION(USE_SYSTEM_PNG        "Use system libPNG for ITK (fixes bundled libpng on
 
 OPTION(MT_BUILD_ITK_TOOLS    "Build ITK-based tools"  ON)
 OPTION(MT_BUILD_VISUAL_TOOLS "Build visual tools (Display, Register, postf, ray_trace) requires OpenGL & Glut"  OFF)
-# GLUT is deprecated on macOS (and freeglut is fragile to build there); use
-# bicgl's GLFW/native-Cocoa windowing backend instead when building on Apple.
-OPTION(MT_USE_GLFW           "Use GLFW for visual tools instead of GLUT" ${APPLE})
+# GLUT is deprecated on macOS and GLX-only on Linux (no x2go / SSH X11); use
+# bicgl's GLFW windowing backend (native Cocoa on macOS, X11/EGL on Linux)
+# everywhere by default. -DMT_USE_GLFW=OFF falls back to GLUT (non-Apple only).
+OPTION(MT_USE_GLFW           "Use GLFW for visual tools instead of GLUT" ON)
 # On Apple, GLUT/freeglut is not supported; always use the GLFW backend.
 IF(APPLE AND NOT MT_USE_GLFW)
   MESSAGE(STATUS "Forcing MT_USE_GLFW=ON on Apple (GLUT/freeglut unsupported)")


### PR DESCRIPTION
Supersedes #215 (that PR's branch was force-pushed to this content and could not be reopened after a stuck-head glitch, so re-filing here). Replaces the original "point GLUT at Homebrew freeglut" change that @vfonov correctly flagged as unnecessary.

Flip the `MT_USE_GLFW` default from `${APPLE}` to **ON** so the visual tools use bicgl's GLFW backend on **every** platform. On Linux the GLFW/X11-EGL backend (bicgl `EGL_windows/`) works over GLX-less sessions (x2go / SSH X11) where GLUT doesn't, and it drops the freeglut build/runtime dependency. The `IF(APPLE …)` floor still forces it ON on macOS; `-DMT_USE_GLFW=OFF` restores GLUT on non-Apple.

**Validated:**
- Full Ubuntu/Fedora/macOS CI matrix green with the visual tools on GLFW (`minimal` + `full`).
- Local Linux build: `Display`/`register` link `libglfw.so.3`, no `libglut`.

**Prerequisite for #209 and #210** — those drop the freeglut packages and rely on this default. Merge this first.

---
Independent slice of #189 (region-disjoint from the other CMake PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)