### PR TITLE
Default MT_BUILD_SHARED_LIBS to ON to match what CI builds and ships

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
 
 # superbuild options
 OPTION(MT_BUILD_LITE         "Build lite version of minc-toolkit, without ITK or visual tools" OFF)
-OPTION(MT_BUILD_SHARED_LIBS  "Build shared libraries." OFF)
+OPTION(MT_BUILD_SHARED_LIBS  "Build shared libraries." ON)
 OPTION(USE_SYSTEM_ZLIB       "Use System ZLIB "       OFF)
 #OPTION(USE_SYSTEM_NIFTI      "Use System NIFTI "       OFF)
 #OPTION(USE_SYSTEM_GIFTI      "Use System GIfTI"       OFF)


### PR DESCRIPTION
One line: `MT_BUILD_SHARED_LIBS` defaults to `ON`.

## Why

The source default currently disagrees with everything we build and ship.

| | setting |
| --- | --- |
| `ci.yml` (3 jobs) | `-DMT_BUILD_SHARED_LIBS=ON` |
| `release.yml` (3 jobs) | `-DMT_BUILD_SHARED_LIBS=ON` |
| `CMakeLists.txt:167` default | `OFF` |

Nothing in CI builds static. So `cmake .. && make` from a fresh clone produces
**the one configuration that is never tested**, and that does not correspond to
any released package. Contributors can't reproduce a shipped artifact with the
defaults, and bugs partition by config — #225 (elastix embedding a build-tree
path in its RUNPATH) is invisible in static builds, which is why it went
unnoticed for so long.

## Why shared rather than making CI static

**Static cannot support ctypes/`dlopen` consumers.** A static build emits only
`libminc2.a` — there is no `libminc2.so` at all:

```
static tree:  minc-build/libminc/libminc2.a
shared tree:  <prefix>/lib/libminc2.so
              <prefix>/lib/libminc2.so.5.3.0
```

pyminc goes through ctypes, so it simply cannot load against a default source
build. No amount of RPATH work fixes a missing shared object.

**The old argument for static no longer applies.** The case was self-contained
relocatable `/opt/minc/<version>` trees without RPATH fragility. Measured on a
full shared superbuild (ITK, Elastix, C3D, visual tools) installed to a scratch
prefix that is *not* in `/etc/ld.so.conf*`:

- 485 installed ELF objects, **0** with unresolved deps with `LD_LIBRARY_PATH` cleared
- binaries run correctly under `env -i` (nothing inherited at all)
- **151/151** ctest

RPATH does the job. Details in #224.

## What I have not measured

The install-size delta. Static duplicates libminc/bicpl/EBTKS/ITK across ~490
binaries and with 60 ITK libraries that is where any blowup would be — but I do
not have a controlled figure and am not going to guess one. If the packaging
size matters for this decision, say so and I'll run a static build with
otherwise identical flags and post real numbers before this merges.

## Risk

This changes what existing source builders get by default. Anyone relying on
static can still pass `-DMT_BUILD_SHARED_LIBS=OFF`, but it is a behaviour change
and probably belongs in release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192DnPpPnLJubhatMWNHg1H
