### PR TITLE
Drop dead USE_SYSTEM_PCRE flags and pcre build deps from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           apt-get install -y \
             build-essential cmake git ccache lsb-release file bc \
             bison flex perl gfortran imagemagick \
-            zlib1g-dev libnetcdf-dev libhdf5-dev libpcre3-dev \
+            zlib1g-dev libnetcdf-dev libhdf5-dev \
             libgsl-dev libfftw3-dev libjpeg-dev libopenjp2-7-dev \
             libarchive-dev libexpat1-dev libopenblas-dev
           if [ "${{ matrix.variant }}" = "full" ]; then
@@ -79,7 +79,6 @@ jobs:
             -DUSE_SYSTEM_ZLIB=ON \
             -DUSE_SYSTEM_NETCDF=ON \
             -DUSE_SYSTEM_HDF5=ON \
-            -DUSE_SYSTEM_PCRE=ON \
             -DUSE_SYSTEM_GSL=ON \
             -DUSE_SYSTEM_FFTW3F=ON \
             -DUSE_SYSTEM_FFTW3D=ON \
@@ -116,7 +115,7 @@ jobs:
           dnf install -y \
             gcc gcc-c++ gcc-gfortran cmake make git ccache file which bc \
             bison flex perl perl-FindBin perl-File-Path ImageMagick \
-            zlib-devel netcdf-devel hdf5-devel pcre-devel gsl-devel \
+            zlib-devel netcdf-devel hdf5-devel gsl-devel \
             fftw-devel libjpeg-turbo-devel openjpeg2-devel \
             libarchive-devel expat-devel openblas-devel
           if [ "${{ matrix.variant }}" = "full" ]; then
@@ -154,7 +153,6 @@ jobs:
             -DUSE_SYSTEM_ZLIB=ON \
             -DUSE_SYSTEM_NETCDF=ON \
             -DUSE_SYSTEM_HDF5=ON \
-            -DUSE_SYSTEM_PCRE=ON \
             -DUSE_SYSTEM_GSL=ON \
             -DUSE_SYSTEM_FFTW3F=ON \
             -DUSE_SYSTEM_FFTW3D=ON \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,17 +99,11 @@ jobs:
       - name: Install build deps
         run: |
           apt-get update
-          # PCRE 1 (libpcre3-dev) is removed in Ubuntu 26.04 (resolute) and
-          # Debian 13 (trixie). Use vendored PCRE there.
-          case "${{ matrix.codename }}" in
-            resolute|trixie) PCRE_PKG="" ;;
-            *)               PCRE_PKG="libpcre3-dev" ;;
-          esac
           # bc is used by the mni_autoreg / patch_morphology test scripts.
           apt-get install -y \
             build-essential cmake git ccache lsb-release file bc \
             bison flex perl gfortran imagemagick \
-            zlib1g-dev libnetcdf-dev libhdf5-dev $PCRE_PKG \
+            zlib1g-dev libnetcdf-dev libhdf5-dev \
             libgsl-dev libfftw3-dev libjpeg-dev libopenjp2-7-dev \
             libarchive-dev libexpat1-dev libopenblas-dev
           if [ "${{ matrix.variant }}" = "full" ]; then
@@ -132,10 +126,6 @@ jobs:
         run: |
           set -euxo pipefail
           if [ "${{ matrix.variant }}" = "full" ]; then FULL=ON; else FULL=OFF; fi
-          case "${{ matrix.codename }}" in
-            resolute|trixie) USE_SYSTEM_PCRE=OFF ;;
-            *)               USE_SYSTEM_PCRE=ON  ;;
-          esac
           cmake -B build \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX=/opt/minc/${{ needs.meta.outputs.version }} \
@@ -155,7 +145,6 @@ jobs:
             -DUSE_SYSTEM_ZLIB=ON \
             -DUSE_SYSTEM_NETCDF=ON \
             -DUSE_SYSTEM_HDF5=ON \
-            -DUSE_SYSTEM_PCRE=$USE_SYSTEM_PCRE \
             -DUSE_SYSTEM_GSL=ON \
             -DUSE_SYSTEM_FFTW3F=ON \
             -DUSE_SYSTEM_FFTW3D=ON \
@@ -216,7 +205,7 @@ jobs:
           dnf install -y \
             gcc gcc-c++ gcc-gfortran cmake make git ccache rpm-build file which bc \
             bison flex perl perl-FindBin perl-File-Path ImageMagick \
-            zlib-devel netcdf-devel hdf5-devel pcre-devel gsl-devel \
+            zlib-devel netcdf-devel hdf5-devel gsl-devel \
             fftw-devel libjpeg-turbo-devel openjpeg2-devel \
             libarchive-devel expat-devel openblas-devel
           if [ "${{ matrix.variant }}" = "full" ]; then
@@ -258,7 +247,6 @@ jobs:
             -DUSE_SYSTEM_ZLIB=ON \
             -DUSE_SYSTEM_NETCDF=ON \
             -DUSE_SYSTEM_HDF5=ON \
-            -DUSE_SYSTEM_PCRE=ON \
             -DUSE_SYSTEM_GSL=ON \
             -DUSE_SYSTEM_FFTW3F=ON \
             -DUSE_SYSTEM_FFTW3D=ON \


### PR DESCRIPTION
886ec1a (*Drop vendored PCRE; oobicpl now uses C++ std::regex*) removed PCRE from the superbuild but left the callers behind.

There is no `USE_SYSTEM_PCRE` option, no `BuildPCRE.cmake`, and no `find_package(PCRE)` anywhere in `CMakeLists.txt` or `cmake-modules/`. So `-DUSE_SYSTEM_PCRE=...` sets an unused cache entry, and CI installs `libpcre3-dev` / `pcre-devel` on every job for nothing.

## What is removed

| File | Removed |
| --- | --- |
| `.github/workflows/ci.yml` | `libpcre3-dev`, `pcre-devel`, `-DUSE_SYSTEM_PCRE=ON` (both jobs) |
| `.github/workflows/release.yml` | the two `case` statements special-casing `resolute`/`trixie`, `$PCRE_PKG`, `pcre-devel`, and three `-DUSE_SYSTEM_PCRE` flags |

The `resolute`/`trixie` special case existed only because PCRE 1 was dropped from Ubuntu 26.04 and Debian 13. With PCRE gone from the build, those distros need no special handling — that is 10 lines of matrix-dependent shell that can go.

## Why removing the packages is safe

Removing a `-D` flag for a non-existent option is a no-op. Removing the `-devel` packages is the only part with any risk, so it was checked:

- No submodule build file references PCRE. The only two hits in the whole tree are `ANTs/CTestCustom.cmake`, where `pcre` appears solely in warning-suppression regexes, and `oobicpl/configure.ac`, the unused autotools path.
- `BuildANTS.cmake` passes `-DANTS_SUPERBUILD:BOOL=OFF`, so ANTs' own bundled PCRE is never built.
- `ldd` across an installed `bin/` finds nothing linking `libpcre`.

Both workflows still parse as YAML.

## Scope

The same dead flag also appears in `centos/SPECS/minc-toolkit.spec`, `debian/rules` and `rpm/minc-toolkit-v2.spec`. Those trees are unused and are removed wholesale in #229, so this PR leaves them alone and stays limited to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019katBUnczdvUS7WQ4RpVoa