### PR TITLE
Patch ITK's znzlib to mangle its symbols, as its niftiio already is

### DIFF
--- a/cmake-modules/BuildITKv4.cmake
+++ b/cmake-modules/BuildITKv4.cmake
@@ -180,6 +180,14 @@ macro(build_itkv4 install_prefix staging_prefix minc_dir)
     URL "${ITKv4_PATH}"
     URL_MD5 "9a3fd160f88a27e664098b94a5de3062"
     UPDATE_COMMAND ""
+    # ITK mangles its bundled niftiio to itk_* but not its znzlib, so ITKznz
+    # exports plain znzopen/znzread/znzseek/... and collides with any other
+    # znzlib in the same binary. Apply the missing half. Submitted upstream as
+    # InsightSoftwareConsortium/ITK#6756; drop this once the pin carries it.
+    PATCH_COMMAND ${CMAKE_COMMAND}
+        -DSRC=<SOURCE_DIR>
+        -DMANGLE=${CMAKE_SOURCE_DIR}/cmake-modules/itk_znzlib_mangle.h
+        -P ${CMAKE_SOURCE_DIR}/cmake-modules/PatchITKZnzMangle.cmake
     SOURCE_DIR ITKv4
     BINARY_DIR ITKv4-build
     CMAKE_GENERATOR ${CMAKE_GEN}

--- a/cmake-modules/PatchITKZnzMangle.cmake
+++ b/cmake-modules/PatchITKZnzMangle.cmake
@@ -1,0 +1,51 @@
+# PatchITKZnzMangle.cmake
+#
+# ITK renames its bundled niftiio symbols to itk_* (itk_nifti_mangle.h, included
+# from ITK's nifti1.h) but never did the same for znzlib, so ITKznz exports the
+# plain znzopen/znzread/znzseek/... names. Anything that links ITK next to a
+# second znzlib -- a system nifti_clib, or our own -- gets two definitions of
+# each: no link error, but ITK's copies land in the executable's dynamic symbol
+# table and interpose over the other library's.
+#
+# This applies the missing half, mirroring what ITK already does for niftiio:
+# drop itk_znzlib_mangle.h beside znzlib.h and include it from there.
+#
+# Submitted upstream as InsightSoftwareConsortium/ITK#6756; drop this once the
+# pinned ITK carries the fix itself.
+#
+# Expects: -DSRC=<ITK source dir>  -DMANGLE=<path to itk_znzlib_mangle.h>
+
+if(NOT EXISTS "${MANGLE}")
+  message(FATAL_ERROR "PatchITKZnzMangle: mangle header not found: ${MANGLE}")
+endif()
+
+set(_znzdir "${SRC}/Modules/ThirdParty/NIFTI/src/nifti/znzlib")
+set(_znzhdr "${_znzdir}/znzlib.h")
+
+if(NOT EXISTS "${_znzhdr}")
+  message(FATAL_ERROR "PatchITKZnzMangle: header not found: ${_znzhdr}")
+endif()
+
+configure_file("${MANGLE}" "${_znzdir}/itk_znzlib_mangle.h" COPYONLY)
+
+file(READ "${_znzhdr}" _orig)
+if(_orig MATCHES "itk_znzlib_mangle\\.h")
+  message(STATUS "PatchITKZnzMangle: ${_znzhdr} already patched")
+else()
+  # Insert at the same point nifti1.h includes itk_nifti_mangle.h: after the
+  # descriptive comment, immediately before the extern "C" block. The mangle
+  # defines must precede both the declarations here and znzlib.c's definitions,
+  # which is satisfied by anything above this line.
+  set(_anchor "/*=================*/\n#ifdef  __cplusplus\nextern \"C\" {")
+  string(FIND "${_orig}" "${_anchor}" _pos)
+  if(_pos EQUAL -1)
+    message(FATAL_ERROR
+      "PatchITKZnzMangle: could not find the extern \"C\" anchor in ${_znzhdr}; "
+      "the pinned ITK has changed and this patch needs revisiting")
+  endif()
+  string(REPLACE "${_anchor}"
+    "// Name mangling, specific to the version of znzlib included with ITK.\n#include \"itk_znzlib_mangle.h\"\n\n${_anchor}"
+    _patched "${_orig}")
+  file(WRITE "${_znzhdr}" "${_patched}")
+  message(STATUS "PatchITKZnzMangle: prefixed znzlib symbols in ${_znzhdr}")
+endif()

--- a/cmake-modules/itk_znzlib_mangle.h
+++ b/cmake-modules/itk_znzlib_mangle.h
@@ -1,0 +1,32 @@
+#ifndef itk_znzlib_mangle_h
+#define itk_znzlib_mangle_h
+
+/*
+This header file mangles all symbols exported from the znzlib library.
+It is intended to be included by ITK's version "znzlib.h".
+
+It is the counterpart of itk_nifti_mangle.h: without it ITKznz exports the
+plain znzlib names, which collide with any other znzlib in the same process
+(e.g. a system nifti_clib pulled in by another library).
+
+Note: znzclose() is a macro over Xznzclose(), so only Xznzclose is mangled;
+the macro expands to the mangled name at the call site.
+*/
+
+#define Xznzclose itk_Xznzclose
+#define znzdopen itk_znzdopen
+#define znzeof itk_znzeof
+#define znzflush itk_znzflush
+#define znzgetc itk_znzgetc
+#define znzgets itk_znzgets
+#define znzopen itk_znzopen
+#define znzprintf itk_znzprintf
+#define znzputc itk_znzputc
+#define znzputs itk_znzputs
+#define znzread itk_znzread
+#define znzrewind itk_znzrewind
+#define znzseek itk_znzseek
+#define znztell itk_znztell
+#define znzwrite itk_znzwrite
+
+#endif


### PR DESCRIPTION
> **Draft — backup.** The real fix is upstream in InsightSoftwareConsortium/ITK#6756. This is the local fallback for as long as that has not landed in the pinned SHA. If it lands, close this and bump the ITK pin instead.

## The gap

ITK renames its bundled niftiio symbols to `itk_*` — `itk_nifti_mangle.h`, included from ITK's `nifti1.h`, 103 names — but never did the same for znzlib. `ITKznz` exports the plain names:

```
Xznzclose  znzdopen  znzeof   znzflush  znzgetc  znzgets  znzopen
znzprintf  znzputc   znzputs  znzread   znzrewind  znzseek  znztell  znzwrite
```

So every tool here that links ITK next to libminc — `c3d`, `elastix`, ANTs, the EZminc tools — carries two definitions of each as soon as the other side's znzlib is unmangled. Nothing fails at link time: ITK's copies are pulled into the executable and land in its **dynamic** symbol table, where they interpose over the other library's.

Measured with ITK `release-4.14`'s own `znzlib.c` linked next to a shared system `nifti_clib`:

| `ITKznz` | unmangled exports | znz names in exe `.dynsym` |
| --- | --- | --- |
| as pinned | 15 | 8 |
| with this patch | 0 | 0 |

## Is it biting today?

No — and that is worth being precise about. Our own NIfTI is already renamed to `minc_*`, so nothing currently in the link exports the plain znz names. This is latent.

It becomes active the moment something else brings its own znzlib, which is exactly what `USE_SYSTEM_NIFTI` does — see #230, which currently has to refuse that combination outright. With this patch (or the upstream one) that restriction can be lifted, which is the point: it is what makes a system NIfTI usable alongside the ITK tools, and therefore what a distribution package would need.

Even without `USE_SYSTEM_NIFTI` the two have already drifted, so the collision is not merely theoretical: ITK's `znzseek`/`znztell` take and return `long` while `nifti_clib` 3.x uses `znz_off_t`, which differ on ILP32 with `_FILE_OFFSET_BITS=64` (measured: 4 bytes against 8); and `sizeof(struct znzptr)` differs between builds that disagree on `HAVE_ZLIB`.

## The change

Mirrors what ITK already does for niftiio, and what we already do for our own NIfTI in `libminc/cmake-modules/PatchNiftiMangle.cmake`:

- `cmake-modules/itk_znzlib_mangle.h` — 15 `#define`s, generated from the symbols ITK's `znzlib.c` actually exports.
- `cmake-modules/PatchITKZnzMangle.cmake` — drops that header beside ITK's `znzlib.h` and includes it from there, at the same point `nifti1.h` includes `itk_nifti_mangle.h`.
- `PATCH_COMMAND` on the `ITKv4` `ExternalProject_Add`, which had none.

`znzclose` is a macro over `Xznzclose`, which is mangled, so it expands to the mangled name at the call site. ITK's only consumer, `itkNiftiImageIO.cxx`, reaches znz through `<nifti1_io.h>` → `<znzlib.h>`, so it picks the mangling up with no further changes.

## Verification

Against a tree laid out like the pinned ITK source:

- patch applies, then reports `already patched` on a second run (idempotent — `PATCH_COMMAND` re-runs on re-configure);
- rebuilding the patched `znzlib.c`: 15 unmangled exports become 0, 15 `itk_*` exports appear;
- if the anchor in `znzlib.h` ever stops matching, the step exits 1 with an explanation rather than silently doing nothing — verified, as is the missing-source case.

Not verified here: a full ITK build, which is hours. The patch touches one vendored third-party header and adds one file next to it, and ITK's own consumer path goes through that header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019katBUnczdvUS7WQ4RpVoa