### PR TITLE
Bump the vendored HDF5 to 1.14.6 and netCDF to 4.9.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,6 +292,10 @@ IF(USE_SYSTEM_NETCDF)
 ELSE()
   INCLUDE(BuildNETCDF)
   build_netcdf( ${CMAKE_INSTALL_PREFIX} ${SUPERBUILD_STAGING_PREFIX})
+  # netCDF 4.9.x links zlib into libnetcdf whether or not HDF5 is enabled.
+  IF(NOT USE_SYSTEM_ZLIB)
+    add_dependencies(NETCDF ZLIB)
+  ENDIF()
 ENDIF()
 
 

--- a/cmake-modules/BuildHDF5.cmake
+++ b/cmake-modules/BuildHDF5.cmake
@@ -62,11 +62,11 @@ macro(build_hdf5 install_prefix staging_prefix)
   SET(HDF_CMAKE_CXX_FLAGS "-fPIC ${CMAKE_CXX_FLAGS}")
   SET(HDF_CMAKE_C_FLAGS   "-fPIC ${CMAKE_C_FLAGS}")
 
-  GET_PACKAGE("https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.6/hdf5-1.14.6.tar.gz" "63426c8e24086634eaf9179a8c5fe9e5" "hdf5-1.14.6.tar.gz" HDF5_PATH )
+  GET_PACKAGE("https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.6/hdf5-1.14.6.tar.gz" "e4defbac30f50d64e1556374aa49e574417c9e72c6b1de7a4ff88c4b1bea6e9b" "hdf5-1.14.6.tar.gz" HDF5_PATH )
 
 ExternalProject_Add(HDF5
   URL "${HDF5_PATH}"
-  URL_MD5 "63426c8e24086634eaf9179a8c5fe9e5"
+  URL_HASH SHA256=e4defbac30f50d64e1556374aa49e574417c9e72c6b1de7a4ff88c4b1bea6e9b
   SOURCE_DIR HDF5
   BINARY_DIR HDF5-build
   CMAKE_GENERATOR ${CMAKE_GEN}

--- a/cmake-modules/BuildHDF5.cmake
+++ b/cmake-modules/BuildHDF5.cmake
@@ -62,11 +62,11 @@ macro(build_hdf5 install_prefix staging_prefix)
   SET(HDF_CMAKE_CXX_FLAGS "-fPIC ${CMAKE_CXX_FLAGS}")
   SET(HDF_CMAKE_C_FLAGS   "-fPIC ${CMAKE_C_FLAGS}")
 
-  GET_PACKAGE("https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-1.12.1/src/hdf5-1.12.1.tar.bz2" "442469fbf43626006346e679c22cf10a" "hdf5-1.12.1.tar.bz2" HDF5_PATH )
+  GET_PACKAGE("https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.6/hdf5-1.14.6.tar.gz" "63426c8e24086634eaf9179a8c5fe9e5" "hdf5-1.14.6.tar.gz" HDF5_PATH )
 
 ExternalProject_Add(HDF5
   URL "${HDF5_PATH}"
-  URL_MD5 "442469fbf43626006346e679c22cf10a"
+  URL_MD5 "63426c8e24086634eaf9179a8c5fe9e5"
   SOURCE_DIR HDF5
   BINARY_DIR HDF5-build
   CMAKE_GENERATOR ${CMAKE_GEN}
@@ -82,35 +82,34 @@ ExternalProject_Add(HDF5
       # Must be RELATIVE to the install prefix. Passing the absolute ${install_prefix}
       # made HDF5 emit a broken package config: `include(${PACKAGE_PREFIX_DIR}//app/install/-targets.cmake)`,
       # so config-mode find_package(HDF5 NO_MODULE) (ITK's preferred path) could not load it.
-      # NOTE: HDF5 1.12.x APPENDS "/hdf5" (the package name) to this dir, so "share/cmake"
-      # installs the package to share/cmake/hdf5 — matching HDF5_DIR below. (HDF5 1.10.x does
-      # NOT append, so develop-1.9.18 uses share/cmake/hdf5 there.)
-      -DHDF5_INSTALL_CMAKE_DIR:PATH=share/cmake
+      # HDF5 1.14.x installs the package to this dir VERBATIM (config/cmake/HDFMacros.cmake
+      # uses it as the install DESTINATION unchanged), so spell out the whole path and keep
+      # it in step with HDF5_DIR below. 1.12.x appended "/hdf5" here; 1.14.x does not.
+      -DHDF5_INSTALL_CMAKE_DIR:PATH=share/cmake/hdf5
       -DHDF5_NO_PACKAGES:BOOL=ON
       -DHDF5_BUILD_CPP_LIB:BOOL=ON
       -DHDF5_BUILD_TOOLS:BOOL=ON
       -DHDF5_BUILD_EXAMPLES:BOOL=OFF
-      -DZLIB_USE_EXTERNAL:BOOL=ON
       # OFF: we build HDF5 as a standalone ExternalProject, not embedded via add_subdirectory.
       # ON suppressed installation of HDF5's own CMake package (hdf5-config.cmake + targets),
       # so config-mode find_package(HDF5 NO_MODULE) — ITK's preferred, system-HDF5-proof path —
       # had nothing to load.
       -DHDF5_EXTERNALLY_CONFIGURED:BOOL=OFF
       -DHDF5_ENABLE_Z_LIB_SUPPORT:BOOL=ON
-      # KEEP for HDF5 1.12.x: H5_ZLIB_HEADER makes CMakeFilters.cmake take the
-      # "zlib already configured by parent" branch and set H5_HAVE_ZLIB_H/LIBZ; the
-      # subsequent `set(LINK_COMP_LIBS ... ${ZLIB_STATIC_LIBRARY})` runs unconditionally,
-      # so our zlib-ng libz.a is still linked into libhdf5. (This differs from HDF5
-      # 1.10.x, where that link line sits inside `if(NOT H5_ZLIB_HEADER)` and setting
-      # the var left libhdf5 with undefined zlib symbols — hence develop-1.9.18 drops it.)
-      -DH5_ZLIB_HEADER:STRING=zlib.h
-      -DH5_HAVE_ZLIB_H:BOOL=ON
-      -DZLIB_INCLUDE_DIRS:STRING=${ZLIB_INCLUDE_DIR}
-      -DZLIB_INCLUDE_DIR:STRING=${ZLIB_INCLUDE_DIR}
-      -DZLIB_LIBRARIES:STRING=${ZLIB_STATIC_LIBRARY}
-      -DZLIB_STATIC_LIBRARY:STRING=${ZLIB_STATIC_LIBRARY}
-      -DZLIB_SHARED_LIBRARY:STRING=${ZLIB_STATIC_LIBRARY}  # for fixing error with restricted binaries on MacOSX
-      -DSKIP_HDF5_FORTRAN_SHARED:BOOL=ON
+      # Let HDF5 resolve zlib itself through module-mode FindZLIB, seeded with the
+      # library the superbuild already resolved. Do NOT set H5_ZLIB_HEADER here: in
+      # 1.14.x that takes the "zlib already configured by the parent project" branch
+      # of CMakeFilters.cmake, which sets H5_ZLIB_FOUND but never appends zlib to
+      # LINK_COMP_LIBS — leaving libhdf5 with undefined deflate/inflate symbols.
+      # (1.12.x appended it unconditionally, hence the flag on that version.)
+      -DZLIB_USE_EXTERNAL:BOOL=OFF
+      -DHDF5_MODULE_MODE_ZLIB:BOOL=ON
+      # Pre-seeded cache entries short-circuit FindZLIB's find_path/find_library.
+      # ZLIB_LIBRARY_RELEASE, not ZLIB_LIBRARY: HDF5 has no FindZLIB of its own, so
+      # this goes to CMake's, where select_library_configurations() derives
+      # ZLIB_LIBRARY from the _RELEASE entry and would overwrite anything we set.
+      -DZLIB_INCLUDE_DIR:PATH=${ZLIB_INCLUDE_DIR}
+      -DZLIB_LIBRARY_RELEASE:FILEPATH=${ZLIB_LIBRARY}
       ${CMAKE_EXTERNAL_PROJECT_ARGS}
   INSTALL_COMMAND $(MAKE) install DESTDIR=${staging_prefix}
   INSTALL_DIR ${staging_prefix}/${install_prefix}

--- a/cmake-modules/BuildNETCDF.cmake
+++ b/cmake-modules/BuildNETCDF.cmake
@@ -53,33 +53,47 @@ macro(build_netcdf install_prefix staging_prefix)
     )
   endif()
 
-  GET_PACKAGE("https://github.com/Unidata/netcdf-c/archive/v4.7.4.tar.gz" "33979e8f0cf4ee31323fc0934282111b" "netcdf-v4.7.4.tar.gz" NETCDF_PATH )
+  GET_PACKAGE("https://github.com/Unidata/netcdf-c/archive/v4.9.3.tar.gz" "bc9eb96e1983bf90fb3a99cc358c5ac3" "netcdf-v4.9.3.tar.gz" NETCDF_PATH )
 
   ExternalProject_Add(NETCDF
     URL "${NETCDF_PATH}"
-    URL_MD5 "33979e8f0cf4ee31323fc0934282111b"
+    URL_MD5 "bc9eb96e1983bf90fb3a99cc358c5ac3"
   SOURCE_DIR NETCDF
   BINARY_DIR NETCDF-build
   LIST_SEPARATOR :::
   CMAKE_GENERATOR ${CMAKE_GEN}
   CMAKE_ARGS
       -DBUILD_SHARED_LIBS:BOOL=OFF
-      -DBUILD_TESTING:BOOL=${NETCDF_TESTS}
-      -DBUILD_TESTSETS:BOOL=${NETCDF_TESTS}
-      -DENABLE_TESTS:BOOL=${NETCDF_TESTS}
-      -DENABLE_V2_API:BOOL=ON
-      -DNC_ENABLE_HDF_16_API:BOOL=OFF
-      -DUSE_HDF5:BOOL=OFF
-      -DUSE_NETCDF4:BOOL=OFF
       -DCMAKE_SKIP_RPATH:BOOL=OFF
-      -DENABLE_DAP:BOOL=OFF
-      -DENABLE_LARGE_FILE_SUPPORT:BOOL=ON
       -DCMAKE_SKIP_INSTALL_RPATH:BOOL=OFF
       -DMACOSX_RPATH:BOOL=ON
       -DCMAKE_INSTALL_RPATH:STRING=${MT_RPATH_ORIGIN}/../lib${LIB_SUFFIX}
-      -DENABLE_NETCDF4:BOOL=OFF
-      -DENABLE_NETCDF_4:BOOL=OFF
       -DCMAKE_INSTALL_PREFIX:PATH=${install_prefix}
+      # netCDF 4.9.3 renamed every project option to a NETCDF_ENABLE_* prefix and ships
+      # no shim for the old spellings: an unprefixed -D is silently ignored and the
+      # option keeps its default, which for most of these is ON.
+      -DBUILD_TESTING:BOOL=${NETCDF_TESTS}
+      -DNETCDF_ENABLE_TESTS:BOOL=${NETCDF_TESTS}
+      # libminc's MINC1 code is written against the netCDF version 2 API.
+      -DNETCDF_ENABLE_V2_API:BOOL=ON
+      -DNETCDF_ENABLE_LARGE_FILE_SUPPORT:BOOL=ON
+      # Build a classic netCDF-3 library and nothing more. MINC2 talks to HDF5 directly,
+      # so netCDF must not link HDF5 as well -- that would put a second, potentially
+      # different, HDF5 underneath libminc. The remaining four default ON in 4.9.x and
+      # would pull in libcurl, libxml2, libzip and the compression filter plugins.
+      -DNETCDF_ENABLE_HDF5:BOOL=OFF
+      -DNETCDF_ENABLE_DAP:BOOL=OFF
+      -DNETCDF_ENABLE_NCZARR:BOOL=OFF
+      -DNETCDF_ENABLE_PLUGINS:BOOL=OFF
+      -DNETCDF_ENABLE_LIBXML2:BOOL=OFF
+      -DNETCDF_ENABLE_REMOTE_FUNCTIONALITY:BOOL=OFF
+      # 4.9.x links zlib into libnetcdf unconditionally (liblib/CMakeLists.txt),
+      # HDF5 or no HDF5, so point it at the zlib the superbuild already resolved --
+      # staged under USE_SYSTEM_ZLIB=OFF, system otherwise. netCDF ships its own
+      # FindZLIB, which populates ZLIB_LIBRARY directly rather than going through
+      # CMake's ZLIB_LIBRARY_RELEASE; a pre-seeded cache entry short-circuits it.
+      -DZLIB_INCLUDE_DIR:PATH=${ZLIB_INCLUDE_DIR}
+      -DZLIB_LIBRARY:FILEPATH=${ZLIB_LIBRARY}
       ${CMAKE_EXTERNAL_PROJECT_ARGS}
       "-DCMAKE_CXX_FLAGS:STRING=-fPIC ${CMAKE_CXX_FLAGS}"
       "-DCMAKE_C_FLAGS:STRING=-fPIC ${CMAKE_C_FLAGS}"

--- a/cmake-modules/BuildNETCDF.cmake
+++ b/cmake-modules/BuildNETCDF.cmake
@@ -53,11 +53,11 @@ macro(build_netcdf install_prefix staging_prefix)
     )
   endif()
 
-  GET_PACKAGE("https://github.com/Unidata/netcdf-c/archive/v4.9.3.tar.gz" "bc9eb96e1983bf90fb3a99cc358c5ac3" "netcdf-v4.9.3.tar.gz" NETCDF_PATH )
+  GET_PACKAGE("https://github.com/Unidata/netcdf-c/archive/v4.9.3.tar.gz" "990f46d49525d6ab5dc4249f8684c6deeaf54de6fec63a187e9fb382cc0ffdff" "netcdf-v4.9.3.tar.gz" NETCDF_PATH )
 
   ExternalProject_Add(NETCDF
     URL "${NETCDF_PATH}"
-    URL_MD5 "bc9eb96e1983bf90fb3a99cc358c5ac3"
+    URL_HASH SHA256=990f46d49525d6ab5dc4249f8684c6deeaf54de6fec63a187e9fb382cc0ffdff
   SOURCE_DIR NETCDF
   BINARY_DIR NETCDF-build
   LIST_SEPARATOR :::

--- a/cmake-modules/DownloadPackage.cmake
+++ b/cmake-modules/DownloadPackage.cmake
@@ -1,9 +1,21 @@
-function(GET_PACKAGE url md5 name local_url )
+# Fetch <url> into the package cache and hand back a file:// URL for the copy,
+# so a rebuild does not download it again.
+#
+# <hash> is either an MD5 (32 hex digits) or a SHA256 (64). Taking both lets
+# call sites move to SHA256 one at a time instead of all at once.
+function(GET_PACKAGE url hash name local_url )
   IF(NOT MT_PACKAGES_PATH STREQUAL "")
     SET(DST "${MT_PACKAGES_PATH}/${name}")
-    file(DOWNLOAD "${url}" "${DST}"  EXPECTED_MD5  "${md5}" SHOW_PROGRESS )
+    STRING(LENGTH "${hash}" _hash_length)
+    IF(_hash_length EQUAL 64)
+      file(DOWNLOAD "${url}" "${DST}" EXPECTED_HASH "SHA256=${hash}" SHOW_PROGRESS )
+    ELSE()
+      file(DOWNLOAD "${url}" "${DST}" EXPECTED_MD5 "${hash}" SHOW_PROGRESS )
+    ENDIF()
     SET(${local_url} "file://${DST}" PARENT_SCOPE)
-  ELSEIF(NOT MT_PACKAGES_PATH STREQUAL "")
+  ELSE()
+    # No cache directory. Hand back the original URL and let
+    # ExternalProject_Add do the download and the hash check itself.
     SET(${local_url} "${url}" PARENT_SCOPE)
-  ENDIF(NOT MT_PACKAGES_PATH STREQUAL "")
+  ENDIF()
 ENDFUNCTION(GET_PACKAGE)


### PR DESCRIPTION
Split out of the original #233, which also carried a CI change. The CI half is now #234, and this PR is the dependency bump alone.

## Why these versions

`ci.yml`'s `fedora:44` jobs already build the whole toolkit — ITKv4, ANTS, C3D and Elastix included — against **system HDF5 1.14.6 and netCDF 4.9.3**, 151/151 tests green. Those are the versions with the most evidence behind them. HDF5 was on 1.12.1 (Dec 2021) and netCDF on 4.7.4 (Mar 2020). The `hdf5-1.14.6.tar.gz` checksum was verified against the published `hdf5-1.14.6.sha256sums.txt`.

## Neither bump is a version-string swap

**HDF5 1.14.x reworked `CMakeFilters.cmake`.** Setting `H5_ZLIB_HEADER` now takes the "zlib already configured by the parent project" branch, which marks zlib found but never appends it to `LINK_COMP_LIBS` — the undefined-`deflate`/`inflate` failure the old comment attributed to 1.10.x. That flag is dropped; HDF5 runs its own module-mode `FindZLIB`, seeded with `ZLIB_INCLUDE_DIR` and `ZLIB_LIBRARY_RELEASE` so `find_path`/`find_library` short-circuit onto whichever zlib the superbuild already resolved. 1.14.x also uses `HDF5_INSTALL_CMAKE_DIR` verbatim as the install `DESTINATION` instead of appending the package name, so it now spells out `share/cmake/hdf5` and `HDF5_DIR` — and ITK's config-mode `find_package` — keep working. `SKIP_HDF5_FORTRAN_SHARED` no longer exists in 1.14.x.

**netCDF 4.9.3 renamed every project option to a `NETCDF_ENABLE_*` prefix with no compatibility shim.** All nine flags in `BuildNETCDF.cmake` had become silent no-ops. Left alone, the bump would have turned the vendored netCDF from a static netCDF-3-only library into a full netCDF-4 pulling in HDF5, libcurl, libxml2 and libzip — a second HDF5 underneath libminc. The flags are renamed, `NC_ENABLE_HDF_16_API` and `BUILD_TESTSETS` are dropped (gone in 4.9.3), and NCZARR, plugins, libxml2 and remote access are explicitly disabled since they are new and default ON. `NETCDF_ENABLE_V2_API` stays ON — libminc's MINC1 code is written against the netCDF version 2 API.

**4.9.x also links zlib into `libnetcdf` unconditionally** (`liblib/CMakeLists.txt`, outside any HDF5 or filter guard), so disabling HDF5 does not remove that dependency. `ZLIB_INCLUDE_DIR`/`ZLIB_LIBRARY` are seeded there too and `NETCDF` is ordered after `ZLIB`, as HDF5 already was. Note netCDF ships its *own* `FindZLIB` that populates `ZLIB_LIBRARY` directly, where CMake's derives it from `ZLIB_LIBRARY_RELEASE` — hence the different spelling at each site, commented in both files.

## Evidence

Both bumps were built and tested green on both platforms while this branch still carried the CI job, in [run 32748695137](https://github.com/BIC-MNI/minc-toolkit-v2/actions/runs/32748695137):

| Job | Libraries | Build | Tests |
| --- | --- | --- | --- |
| `superbuild` minimal / full | **vendored** | pass | pass |
| `macos` minimal / full | **vendored** | pass | pre-existing failure, see below |
| `ubuntu`, `fedora` minimal / full | system | pass | pass |

`superbuild (full)` is the strongest single data point: ANTs, C3D, Elastix, the visual tools and all nine vendored libraries plus OpenBLAS and ITK, all from source, tests green, 276 MB tarball produced.

**On this PR alone, macOS is the only job that exercises these changes** — every Linux job here sets `USE_SYSTEM_HDF5`/`NETCDF=ON`. That is precisely the gap #234 closes. Merging #234 first would give this PR Linux coverage as well; merging this first is also fine, since macOS already covers it.

## Unrelated pre-existing failure

`macos` fails `nu_reference_1` on this branch — and identically on `develop-1.9.18` without these changes ([run 32746963355](https://github.com/BIC-MNI/minc-toolkit-v2/actions/runs/32746963355)), with a bit-identical `relative RMS difference: 0.000850981867212377 larger then 0.0001`. Not caused by this PR. It has gone unnoticed because the macOS jobs have been dying at the build step on flaky upstream downloads before reaching the test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LkDsdVKLFoLtnw25B2aiYE
