### PR TITLE
Build the fully vendored superbuild in CI and ship it as a relocatable tarball

### DIFF
--- a/.github/scripts/check-relocation.sh
+++ b/.github/scripts/check-relocation.sh
@@ -29,7 +29,7 @@ echo "=== 1. Config script ==="
 [ "${MINC_TOOLKIT:-}" = "$PREFIX" ] \
   || fail "config script set MINC_TOOLKIT=${MINC_TOOLKIT:-unset}, expected $PREFIX"
 # Asserted, not assumed: the checks below rely on the config script exporting
-# this, and on MNI_DATAPATH and LD_LIBRARY_PATH alongside it.
+# this, and on MNI_DATAPATH alongside it.
 [ "${MINC_COMPRESS:-}" = 4 ] || fail "config script did not export MINC_COMPRESS=4"
 echo "MINC_TOOLKIT=$MINC_TOOLKIT"
 echo "MINC_TOOLKIT_VERSION=${MINC_TOOLKIT_VERSION:-unset}"

--- a/.github/scripts/check-relocation.sh
+++ b/.github/scripts/check-relocation.sh
@@ -82,14 +82,19 @@ echo "=== 3. Every installed command starts ==="
 # that is fine and is not what this looks at. What matters is the loader or the
 # interpreter giving up, which is what a broken relocation looks like.
 #
-# Perl scripts that cannot find a module are a different problem: these modules
-# are missing from the .deb and .rpm too, which declare only "perl". Report
-# them, and fail only on a script that is not already known to be in that state.
-#   normalize_mri, smooth_mask, lgmask  -- ctime.pl, dropped from perl core in 5.30
+# A perl script that cannot find a module is a different problem, and not one
+# this tarball introduced. Report those, and fail only on a script that is not
+# already known to be in that state:
+#   normalize_mri, smooth_mask, lgmask  -- ctime.pl, removed from perl core in
+#                                          5.16. Fixed in BIC-MNI/inormalize#5
+#                                          and BIC-MNI/conglomerate#7; drop these
+#                                          three from the list when those pins
+#                                          bump, so a regression cannot hide.
 #   xfmdecomp.pl                        -- Math::MatrixReal (CPAN)
 #   patch_segmentation_pipeline.pl      -- Parallel::ForkManager (CPAN)
-#   ana2mnc_xfm_reduce.pl               -- Parallel::ForkManager (CPAN)
-known_perl_gap='normalize_mri|smooth_mask|lgmask|xfmdecomp[.]pl|patch_segmentation_pipeline[.]pl|ana2mnc_xfm_reduce[.]pl'
+# The two CPAN modules stay: nothing ships them, and #238 declares them as
+# package dependencies instead.
+known_perl_gap='normalize_mri|smooth_mask|lgmask|xfmdecomp[.]pl|patch_segmentation_pipeline[.]pl'
 loader_error='error while loading shared libraries|cannot open shared object file|symbol lookup error|undefined symbol'
 
 cd "$WORK"

--- a/.github/scripts/check-relocation.sh
+++ b/.github/scripts/check-relocation.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+# Check that an unpacked toolkit tree works from a prefix the build never named.
+#
+# The superbuild configures with CMAKE_INSTALL_PREFIX=/opt/minc/<version>, but
+# the tarball unpacks anywhere. Every run path, every vendored library and every
+# data path must therefore resolve relative to wherever the tree landed. This
+# script is the gate for that claim, and ci.yml and release.yml both call it.
+#
+# Usage: check-relocation.sh <unpacked-prefix> <minimal|full>
+
+set -euo pipefail
+
+PREFIX=$(cd -- "$1" && pwd -P)
+VARIANT=$2
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# mincstats takes one volume at a time; reading each result back is the check
+# that the tool that wrote it produced something usable.
+means() { for v in "$@"; do printf '%s mean: ' "$v"; mincstats -quiet -mean "$v"; done; }
+
+echo "=== 1. Config script ==="
+# The script finds the prefix through BASH_SOURCE. If it instead reports the
+# path baked in at configure time, nothing else in this file means anything.
+# shellcheck source=/dev/null
+. "$PREFIX/minc-toolkit-config.sh"
+[ "${MINC_TOOLKIT:-}" = "$PREFIX" ] \
+  || fail "config script set MINC_TOOLKIT=${MINC_TOOLKIT:-unset}, expected $PREFIX"
+# Asserted, not assumed: the checks below rely on the config script exporting
+# this, and on MNI_DATAPATH and LD_LIBRARY_PATH alongside it.
+[ "${MINC_COMPRESS:-}" = 4 ] || fail "config script did not export MINC_COMPRESS=4"
+echo "MINC_TOOLKIT=$MINC_TOOLKIT"
+echo "MINC_TOOLKIT_VERSION=${MINC_TOOLKIT_VERSION:-unset}"
+
+echo "=== 2. Dynamic linkage of every shipped ELF object ==="
+# Every library the tarball ships, by soname. A system copy of any of these
+# winning the search means the vendored build escaped into the distribution's
+# libraries, which is the failure this whole job exists to catch.
+find "$PREFIX" -name '*.so*' -printf '%f\n' | sort -u > "$WORK/shipped"
+
+mapfile -t objects < <(
+  find "$PREFIX" -type f -exec file -N {} + 2>/dev/null \
+    | awk -F': ' '/ELF .*(executable|shared object)/ { print $1 }' | sort
+)
+[ "${#objects[@]}" -gt 0 ] || fail "found no ELF objects under $PREFIX"
+
+: > "$WORK/resolved"
+for obj in "${objects[@]}"; do
+  # ldd's exit status is not dependable across glibc versions when a dependency
+  # is missing, so decide what to skip from the message, not the status.
+  out=$(ldd "$obj" 2>&1) || true
+  case $out in *'not a dynamic executable'*) continue ;; esac
+  if printf '%s\n' "$out" | grep -q 'not found'; then
+    printf '%s\n' "$out" | grep 'not found' >&2
+    fail "$obj has unresolved libraries"
+  fi
+  printf '%s\n' "$out" | awk '$2 == "=>" && $3 ~ /^\// { print $3 }' >> "$WORK/resolved"
+done
+sort -u "$WORK/resolved" -o "$WORK/resolved"
+grep -v "^$PREFIX/" "$WORK/resolved" > "$WORK/external" || true
+
+while read -r lib; do
+  [ -n "$lib" ] || continue
+  case $lib in
+    /lib/*|/lib64/*|/usr/lib/*|/usr/lib64/*) ;;
+    # Anywhere else means the build tree: a run path or a NEEDED entry pointing
+    # at the superbuild staging area, which does not travel with the tarball.
+    *) fail "resolves outside the tarball and outside the system library directories: $lib" ;;
+  esac
+  if grep -qxF "$(basename "$lib")" "$WORK/shipped"; then
+    fail "a system copy shadows a library the tarball ships: $lib"
+  fi
+done < "$WORK/external"
+
+echo "Checked ${#objects[@]} ELF objects. Libraries taken from the host:"
+sed 's|.*/||' "$WORK/external" | sort -u | sed 's/^/  /'
+
+echo "=== 3. Every installed command starts ==="
+# Run each one with no arguments. Almost all print usage and exit non-zero;
+# that is fine and is not what this looks at. What matters is the loader or the
+# interpreter giving up, which is what a broken relocation looks like.
+#
+# Perl scripts that cannot find a module are a different problem: these modules
+# are missing from the .deb and .rpm too, which declare only "perl". Report
+# them, and fail only on a script that is not already known to be in that state.
+#   normalize_mri, smooth_mask, lgmask  -- ctime.pl, dropped from perl core in 5.30
+#   xfmdecomp.pl                        -- Math::MatrixReal (CPAN)
+#   patch_segmentation_pipeline.pl      -- Parallel::ForkManager (CPAN)
+#   ana2mnc_xfm_reduce.pl               -- Parallel::ForkManager (CPAN)
+known_perl_gap='normalize_mri|smooth_mask|lgmask|xfmdecomp[.]pl|patch_segmentation_pipeline[.]pl|ana2mnc_xfm_reduce[.]pl'
+loader_error='error while loading shared libraries|cannot open shared object file|symbol lookup error|undefined symbol'
+
+cd "$WORK"
+started=0
+: > "$WORK/loader-failed"
+: > "$WORK/perl-gap"
+for cmd in "$PREFIX"/bin/* "$PREFIX"/pipeline/*; do
+  [ -f "$cmd" ] && [ -x "$cmd" ] || continue
+  started=$((started + 1))
+  out=$(timeout 20 "$cmd" </dev/null 2>&1 || true)
+  if line=$(printf '%s' "$out" | grep -m1 -E "$loader_error"); then
+    printf '%s: %s\n' "${cmd#"$PREFIX"/}" "$line" >> "$WORK/loader-failed"
+  elif line=$(printf '%s' "$out" | grep -m1 "Can't locate"); then
+    printf '%s: %s\n' "${cmd#"$PREFIX"/}" "$line" >> "$WORK/perl-gap"
+  fi
+done
+echo "Started $started commands."
+
+if [ -s "$WORK/perl-gap" ]; then
+  echo "Perl scripts with an unmet module dependency (not a relocation defect):"
+  sed 's/^/  /' "$WORK/perl-gap"
+  if grep -qvE "(^|/)($known_perl_gap):" "$WORK/perl-gap"; then
+    grep -vE "(^|/)($known_perl_gap):" "$WORK/perl-gap" >&2
+    fail "a perl script outside the known set cannot find its modules"
+  fi
+fi
+
+if [ -s "$WORK/loader-failed" ]; then
+  cat "$WORK/loader-failed" >&2
+  fail "$(wc -l < "$WORK/loader-failed") command(s) could not load their libraries"
+fi
+
+echo "=== 4. Core MINC tools do real work ==="
+GEOM="-nelements 64 64 64 -step 2 2 2 -start -64 -64 -64 -center 0 0 0"
+# Same geometry as the mni_autoreg ellipse0 test; the defaults do not overlap a
+# small volume.
+# shellcheck disable=SC2086
+make_phantom -clobber -ellipse $GEOM phantom.mnc
+# shellcheck disable=SC2086
+MINC_COMPRESS=0 make_phantom -clobber -ellipse $GEOM plain.mnc
+mincinfo phantom.mnc
+minccalc -clobber -expression 'A[0]*2' phantom.mnc doubled.mnc
+mincresample -clobber -like phantom.mnc phantom.mnc resampled.mnc
+mincblur -clobber -fwhm 4 phantom.mnc blurred
+means doubled.mnc resampled.mnc blurred_blur.mnc
+
+# MINC_COMPRESS=4 comes from the config script, so the write above went through
+# libminc -> HDF5 -> zlib. Prove the deflate filter really ran instead of
+# trusting the variable: the same volume written with compression off is many
+# times larger.
+packed=$(stat -c%s phantom.mnc)
+plain=$(stat -c%s plain.mnc)
+echo "phantom.mnc: $packed bytes compressed, $plain bytes uncompressed"
+[ "$packed" -lt "$((plain / 2))" ] \
+  || fail "MINC_COMPRESS=4 gained nothing ($packed vs $plain); the zlib path did not run"
+
+echo "=== 5. ITK-based MINC tools ==="
+# EZminc and patch_morphology are built for both variants, and they are the
+# tools that load the vendored ITK out of lib/InsightToolkit.
+itk_resample --clobber phantom.mnc itk_resampled.mnc --like phantom.mnc
+itk_morph --clobber --exp 'D[1]' phantom.mnc itk_morphed.mnc
+itk_distance --clobber phantom.mnc itk_distance.mnc
+itk_convert --clobber phantom.mnc phantom.nii   # ITK NIfTI IO
+minc_anlm --clobber phantom.mnc denoised.mnc    # ITK + OpenBLAS
+means itk_resampled.mnc itk_morphed.mnc itk_distance.mnc denoised.mnc
+[ -s phantom.nii ] || fail "itk_convert wrote an empty NIfTI file"
+
+if [ "$VARIANT" != full ]; then
+  echo "Variant is $VARIANT; ANTs, C3D, Elastix and ABC are not in this tarball."
+  echo "OK: $PREFIX relocated cleanly."
+  exit 0
+fi
+
+echo "=== 6. Bundled third-party commands ==="
+# Named rather than probed: a tool missing from the full tarball has to be red,
+# not silently skipped.
+for cmd in antsRegistration antsApplyTransforms N4BiasFieldCorrection ImageMath \
+           c3d elastix transformix ABC_MINC \
+           Display register register_resample postf ray_trace xdisp; do
+  [ -x "$PREFIX/bin/$cmd" ] || fail "$cmd is missing from the full tarball"
+done
+
+# ANTs and C3D, on the volumes written above.
+N4BiasFieldCorrection -d 3 -i phantom.mnc -o n4.mnc
+antsApplyTransforms -d 3 -i phantom.mnc -r phantom.mnc -o ants_warped.mnc
+ImageMath 3 ants_math.mnc + phantom.mnc 1
+c3d phantom.nii -info
+c3d phantom.nii -smooth 1mm -o c3d_smoothed.nii
+means n4.mnc ants_warped.mnc ants_math.mnc
+[ -s c3d_smoothed.nii ] || fail "c3d wrote an empty NIfTI file"
+
+# Elastix needs a parameter file to do anything; its version banner is enough to
+# show the binary and its ITK libraries loaded. ABC has neither --version nor
+# --help and exits 1 on a usage error, so starting it is the whole check, and
+# step 3 already did that.
+elastix --version
+transformix --version
+
+# The visual tools need a display, so step 3 -- which starts every command and
+# only objects to the loader giving up -- is as far as this can go for them.
+
+echo "OK: $PREFIX relocated cleanly."

--- a/.github/scripts/check-relocation.sh
+++ b/.github/scripts/check-relocation.sh
@@ -104,7 +104,10 @@ started=0
 for cmd in "$PREFIX"/bin/* "$PREFIX"/pipeline/*; do
   [ -f "$cmd" ] && [ -x "$cmd" ] || continue
   started=$((started + 1))
-  out=$(timeout 20 "$cmd" </dev/null 2>&1 || true)
+  # Capped: two commands in the full tarball write enough in 20 seconds to
+  # exhaust the command-substitution buffer ("xrealloc: cannot allocate").
+  # head closing the pipe also stops them early instead of at the timeout.
+  out=$(timeout 20 "$cmd" </dev/null 2>&1 | head -c 65536 || true)
   if line=$(printf '%s' "$out" | grep -m1 -E "$loader_error"); then
     printf '%s: %s\n' "${cmd#"$PREFIX"/}" "$line" >> "$WORK/loader-failed"
   elif line=$(printf '%s' "$out" | grep -m1 "Can't locate"); then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,3 +219,102 @@ jobs:
           set -euxo pipefail
           cd build
           ctest --output-on-failure -j"$(sysctl -n hw.ncpu)"
+
+  # Everything vendored. Passing no USE_SYSTEM_* flags leaves them all at their
+  # OFF default, so the superbuild compiles zlib, HDF5, netCDF, GSL, FFTW, JPEG,
+  # OpenJPEG, libarchive, OpenBLAS and ITK from source. Every other Linux job in
+  # this file sets nine of those to ON, so without this one the vendored path is
+  # never built on Linux at all. It also produces the relocatable tarball that
+  # release.yml ships.
+  superbuild:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [minimal, full]
+    # 22.04, not 24.04: the tarball has to run somewhere other than the machine
+    # that built it, so build against the oldest glibc (2.35) whose CMake (3.22)
+    # still satisfies every vendored dependency (HDF5 asks the most: >= 3.18).
+    container: 'ubuntu:22.04'
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      CCACHE_DIR: /root/.ccache
+      CCACHE_MAXSIZE: 2G
+    steps:
+      - name: Install build deps
+        run: |
+          apt-get update
+          # Deliberately no -dev package for anything the superbuild vendors: the
+          # point of this job is that nothing quietly falls back to a system copy.
+          # bc is used by the mni_autoreg / patch_morphology test scripts.
+          apt-get install -y \
+            build-essential cmake git ccache lsb-release file bc \
+            bison flex perl gfortran imagemagick
+          # The visual tools have no vendored windowing stack -- bicgl links the
+          # system GLFW, exactly as the .deb does.
+          if [ "${{ matrix.variant }}" = "full" ]; then
+            apt-get install -y libx11-dev libxi-dev libxmu-dev \
+              libgl-dev libglu1-mesa-dev libglfw3-dev libxrandr-dev libxext-dev
+          fi
+      - name: Allow git to read the workspace owned by the runner user
+        run: git config --global --add safe.directory '*'
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - uses: actions/cache@v6
+        with:
+          path: /root/.ccache
+          key: ccache-ci-superbuild-${{ matrix.variant }}-${{ github.sha }}
+          restore-keys: |
+            ccache-ci-superbuild-${{ matrix.variant }}-
+      - name: Configure + build
+        run: |
+          set -euxo pipefail
+          if [ "${{ matrix.variant }}" = "full" ]; then FULL=ON; else FULL=OFF; fi
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=/opt/minc/ci \
+            -DMT_BUILD_SHARED_LIBS=ON \
+            -DBUILD_TESTING=ON \
+            -DMT_BUILD_ITK_TOOLS=ON \
+            -DMT_BUILD_ANTS=$FULL \
+            -DMT_BUILD_C3D=$FULL \
+            -DMT_BUILD_ELASTIX=$FULL \
+            -DMT_BUILD_VISUAL_TOOLS=$FULL \
+            -DMT_BUILD_OPENBLAS=ON \
+            -DMT_USE_OPENMP=ON \
+            -DUSE_SYSTEM_ITK=OFF \
+            .
+          cmake --build build -j"$(nproc)"
+          df -h && du -sh build/ || true
+      - name: Run test suite
+        run: |
+          set -euxo pipefail
+          cd build
+          ctest --output-on-failure -j"$(nproc)"
+      - name: Build tarball
+        run: |
+          set -euxo pipefail
+          DESTDIR="$PWD/pkgroot" cmake --build build --target install
+          TOP="minc-toolkit-${GITHUB_SHA:0:7}"
+          mv pkgroot/opt/minc/ci "pkgroot/$TOP"
+          tar czf "$TOP-${{ matrix.variant }}-linux-x86_64.tar.gz" -C pkgroot "$TOP"
+          ls -lh ./*.tar.gz
+      - name: Check the tarball actually relocates
+        run: |
+          set -euxo pipefail
+          # Unpack somewhere the build never mentioned. Sourcing the config script
+          # and writing a volume covers the whole chain the run paths have to carry:
+          # libminc -> HDF5 -> zlib (MINC_COMPRESS=4 puts the write through deflate).
+          mkdir -p /tmp/relocated
+          tar xzf ./*.tar.gz -C /tmp/relocated
+          . /tmp/relocated/minc-toolkit-*/minc-toolkit-config.sh
+          # Same geometry as the mni_autoreg ellipse0 test; the defaults do not
+          # overlap a small volume.
+          make_phantom -clobber -ellipse -nelements 64 64 64 -step 2 2 2 -start -64 -64 -64 -center 0 0 0 /tmp/relocated/phantom.mnc
+          mincinfo /tmp/relocated/phantom.mnc
+      - uses: actions/upload-artifact@v7
+        with:
+          name: superbuild-${{ matrix.variant }}
+          path: '*.tar.gz'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,9 +226,14 @@ jobs:
   # other Linux job in this file sets nine of those to ON, so without this one
   # the vendored path is never built on Linux at all.
   #
-  # `full` turns on every component the tree can build -- ANTs, C3D, Elastix,
-  # ABC, the visual tools -- and both variants enable the dcm2mnc integration
-  # tests. It also produces the relocatable tarball that release.yml ships.
+  # `full` turns on every component the tree can build: ANTs, C3D, Elastix, ABC
+  # and the visual tools. It also produces the relocatable tarball that
+  # release.yml ships.
+  #
+  # MT_BUILD_DCM2MNC_TESTS stays off here. minctools passes
+  # DOWNLOAD_EXTRACT_TIMESTAMP to ExternalProject_Add unconditionally, and CMake
+  # only accepts it from 3.24; on 22.04's 3.22 it reaches the generated extract
+  # script as a stray execute_process argument and the download step fails.
   superbuild:
     runs-on: ubuntu-latest
     strategy:
@@ -288,7 +293,6 @@ jobs:
             -DMT_BUILD_VISUAL_TOOLS=$FULL \
             -DMT_BUILD_OPENBLAS=ON \
             -DMT_USE_OPENMP=ON \
-            -DMT_BUILD_DCM2MNC_TESTS=ON \
             -DUSE_SYSTEM_ITK=OFF \
             .
           cmake --build build -j"$(nproc)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,12 +220,15 @@ jobs:
           cd build
           ctest --output-on-failure -j"$(sysctl -n hw.ncpu)"
 
-  # Everything vendored. Passing no USE_SYSTEM_* flags leaves them all at their
-  # OFF default, so the superbuild compiles zlib, HDF5, netCDF, GSL, FFTW, JPEG,
-  # OpenJPEG, libarchive, OpenBLAS and ITK from source. Every other Linux job in
-  # this file sets nine of those to ON, so without this one the vendored path is
-  # never built on Linux at all. It also produces the relocatable tarball that
-  # release.yml ships.
+  # Everything vendored, everything built. Passing no USE_SYSTEM_* flags leaves
+  # them all at their OFF default, so the superbuild compiles zlib, HDF5, netCDF,
+  # GSL, FFTW, JPEG, OpenJPEG, libarchive, OpenBLAS and ITK from source. Every
+  # other Linux job in this file sets nine of those to ON, so without this one
+  # the vendored path is never built on Linux at all.
+  #
+  # `full` turns on every component the tree can build -- ANTs, C3D, Elastix,
+  # ABC, the visual tools -- and both variants enable the dcm2mnc integration
+  # tests. It also produces the relocatable tarball that release.yml ships.
   superbuild:
     runs-on: ubuntu-latest
     strategy:
@@ -281,9 +284,11 @@ jobs:
             -DMT_BUILD_ANTS=$FULL \
             -DMT_BUILD_C3D=$FULL \
             -DMT_BUILD_ELASTIX=$FULL \
+            -DMT_BUILD_ABC=$FULL \
             -DMT_BUILD_VISUAL_TOOLS=$FULL \
             -DMT_BUILD_OPENBLAS=ON \
             -DMT_USE_OPENMP=ON \
+            -DMT_BUILD_DCM2MNC_TESTS=ON \
             -DUSE_SYSTEM_ITK=OFF \
             .
           cmake --build build -j"$(nproc)"
@@ -311,16 +316,13 @@ jobs:
       - name: Check the tarball actually relocates
         run: |
           set -euxo pipefail
-          # Unpack somewhere the build never mentioned. Sourcing the config script
-          # and writing a volume covers the whole chain the run paths have to carry:
-          # libminc -> HDF5 -> zlib (MINC_COMPRESS=4 puts the write through deflate).
+          # Unpack somewhere the build never mentioned and hand the tree to the
+          # check: the config script finds its own prefix, every shipped object
+          # resolves its libraries inside the tarball, every installed command
+          # starts, and the MINC, ITK and third-party tools do real work.
           mkdir -p /tmp/relocated
           tar xzf ./*.tar.gz -C /tmp/relocated
-          . /tmp/relocated/minc-toolkit-*/minc-toolkit-config.sh
-          # Same geometry as the mni_autoreg ellipse0 test; the defaults do not
-          # overlap a small volume.
-          make_phantom -clobber -ellipse -nelements 64 64 64 -step 2 2 2 -start -64 -64 -64 -center 0 0 0 /tmp/relocated/phantom.mnc
-          mincinfo /tmp/relocated/phantom.mnc
+          .github/scripts/check-relocation.sh /tmp/relocated/minc-toolkit-* '${{ matrix.variant }}'
       - uses: actions/upload-artifact@v7
         with:
           name: superbuild-${{ matrix.variant }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,6 +297,13 @@ jobs:
         run: |
           set -euxo pipefail
           DESTDIR="$PWD/pkgroot" cmake --build build --target install
+          # Strip the ELF objects. CPACK_STRIP_FILES only covers the CPack
+          # generators, so this tree would otherwise ship whatever debug info the
+          # build produced -- and the toolkit's own components compile with -g.
+          # Perl scripts, data and man pages are matched out by file(1).
+          find pkgroot -type f -exec file -N {} + 2>/dev/null \
+            | awk -F': ' '/ELF .*(executable|shared object)/ { print $1 }' \
+            | xargs -r strip --strip-unneeded 2>/dev/null || true
           TOP="minc-toolkit-${GITHUB_SHA:0:7}"
           mv pkgroot/opt/minc/ci "pkgroot/$TOP"
           tar czf "$TOP-${{ matrix.variant }}-linux-x86_64.tar.gz" -C pkgroot "$TOP"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,9 +337,115 @@ jobs:
           name: ${{ matrix.runner }}-${{ matrix.variant }}
           path: '*.pkg'
 
+  # Fully vendored superbuild -> one relocatable tarball per variant, for people
+  # who are not on a distro this workflow packages for, or who cannot install to
+  # a system prefix. Passing no USE_SYSTEM_* flags leaves them at their OFF
+  # default, so zlib, HDF5, netCDF, GSL, FFTW, JPEG, OpenJPEG, libarchive,
+  # OpenBLAS and ITK are all built from source and shipped inside the tarball.
+  superbuild-tarball:
+    needs: meta
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [minimal, full]
+    # 22.04, not 24.04: this artifact has to run somewhere other than the machine
+    # that built it, so build against the oldest glibc (2.35) whose CMake (3.22)
+    # still satisfies every vendored dependency (HDF5 asks the most: >= 3.18).
+    container: 'ubuntu:22.04'
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      CCACHE_DIR: /root/.ccache
+      CCACHE_MAXSIZE: 2G
+    steps:
+      - name: Install build deps
+        run: |
+          apt-get update
+          # Deliberately no -dev package for anything the superbuild vendors, so
+          # nothing quietly falls back to a system copy and escapes the tarball.
+          # bc is used by the mni_autoreg / patch_morphology test scripts.
+          apt-get install -y \
+            build-essential cmake git ccache lsb-release file bc \
+            bison flex perl gfortran imagemagick
+          # The visual tools have no vendored windowing stack -- bicgl links the
+          # system GLFW, exactly as the .deb does.
+          if [ "${{ matrix.variant }}" = "full" ]; then
+            apt-get install -y libx11-dev libxi-dev libxmu-dev \
+              libgl-dev libglu1-mesa-dev libglfw3-dev libxrandr-dev libxext-dev
+          fi
+      - name: Allow git to read the workspace owned by the runner user
+        run: git config --global --add safe.directory '*'
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - uses: actions/cache@v6
+        with:
+          path: /root/.ccache
+          key: ccache-superbuild-${{ matrix.variant }}-${{ github.sha }}
+          restore-keys: |
+            ccache-superbuild-${{ matrix.variant }}-
+      - name: Configure + build
+        run: |
+          set -euxo pipefail
+          if [ "${{ matrix.variant }}" = "full" ]; then FULL=ON; else FULL=OFF; fi
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=/opt/minc/${{ needs.meta.outputs.version }} \
+            -DMINC_TOOLKIT_PACKAGE_VERSION_MAJOR=${{ needs.meta.outputs.major }} \
+            -DMINC_TOOLKIT_PACKAGE_VERSION_MINOR=${{ needs.meta.outputs.minor }} \
+            -DMINC_TOOLKIT_PACKAGE_VERSION_PATCH=${{ needs.meta.outputs.patch }} \
+            -DMT_BUILD_SHARED_LIBS=ON \
+            -DBUILD_TESTING=ON \
+            -DMT_BUILD_ITK_TOOLS=ON \
+            -DMT_BUILD_ANTS=$FULL \
+            -DMT_BUILD_C3D=$FULL \
+            -DMT_BUILD_ELASTIX=$FULL \
+            -DMT_BUILD_VISUAL_TOOLS=$FULL \
+            -DMT_BUILD_OPENBLAS=ON \
+            -DMT_USE_OPENMP=ON \
+            -DUSE_SYSTEM_ITK=OFF \
+            .
+          cmake --build build -j"$(nproc)"
+          df -h && du -sh build/ || true
+      - name: Run test suite
+        run: |
+          set -euxo pipefail
+          cd build
+          ctest --output-on-failure -j"$(nproc)"
+      - name: Build tarball
+        run: |
+          set -euxo pipefail
+          VER="${{ needs.meta.outputs.version }}"
+          DESTDIR="$PWD/pkgroot" cmake --build build --target install
+          # Repoint the top directory at a self-describing name: the tree unpacks
+          # anywhere, so the /opt/minc/<ver> prefix it was configured with is only
+          # a build-time detail.
+          mv "pkgroot/opt/minc/$VER" "pkgroot/minc-toolkit-$VER"
+          tar czf "minc-toolkit-v2-$VER-${{ matrix.variant }}-linux-x86_64.tar.gz" \
+            -C pkgroot "minc-toolkit-$VER"
+          ls -lh ./*.tar.gz
+      - name: Check the tarball actually relocates
+        run: |
+          set -euxo pipefail
+          # Unpack somewhere the build never mentioned. Sourcing the config script
+          # and writing a volume covers the whole chain the run paths have to carry:
+          # libminc -> HDF5 -> zlib (MINC_COMPRESS=4 puts the write through deflate).
+          mkdir -p /tmp/relocated
+          tar xzf ./*.tar.gz -C /tmp/relocated
+          . /tmp/relocated/minc-toolkit-*/minc-toolkit-config.sh
+          # Same geometry as the mni_autoreg ellipse0 test; the defaults do not
+          # overlap a small volume.
+          make_phantom -clobber -ellipse -nelements 64 64 64 -step 2 2 2 -start -64 -64 -64 -center 0 0 0 /tmp/relocated/phantom.mnc
+          mincinfo /tmp/relocated/phantom.mnc
+      - uses: actions/upload-artifact@v7
+        with:
+          name: tarball-${{ matrix.variant }}
+          path: '*.tar.gz'
+
   release:
     if: github.event_name == 'push'
-    needs: [meta, source-tarball, deb, rpm, macos]
+    needs: [meta, source-tarball, deb, rpm, macos, superbuild-tarball]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8
@@ -358,6 +464,13 @@ jobs:
             **Linux**:
             - Ubuntu 22.04 / 24.04 / 26.04 / Debian 11 / 12 / 13: `sudo dpkg -i minc-toolkit-v2_<version>_<distro>-<codename>-<variant>_amd64.deb && sudo apt-get install -fy`
             - Fedora 42 / 43 / 44: `sudo dnf install minc-toolkit-v2-<version>-fc<release>-<variant>.x86_64.rpm`
+
+            **Linux, any distro** (`minc-toolkit-v2-<version>-<variant>-linux-x86_64.tar.gz`):
+            - Self-contained and relocatable — unpack it anywhere, no root needed:
+              `tar xzf minc-toolkit-v2-<version>-<variant>-linux-x86_64.tar.gz -C ~/opt`
+              then `source ~/opt/minc-toolkit-<version>/minc-toolkit-config.sh`.
+            - Every dependency the toolkit vendors (zlib, HDF5, netCDF, GSL, FFTW, JPEG, OpenJPEG, libarchive, OpenBLAS, ITK) is inside the tarball. Only glibc 2.35+ and, for the `full` variant, the system X11/OpenGL/GLFW runtime libraries are needed.
+            - Source the config script from **bash**: it locates the prefix through `BASH_SOURCE`, and other shells fall back to the path baked in at build time.
 
             **macOS** (Apple Silicon / arm64; built on macos-14 / 15 / 26 runners):
             - Open the matching `.pkg` for your macOS version. **First run is unsigned**: right-click → Open to bypass Gatekeeper.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -477,7 +477,7 @@ jobs:
             - Self-contained and relocatable — unpack it anywhere, no root needed:
               `tar xzf minc-toolkit-v2-<version>-<variant>-linux-x86_64.tar.gz -C ~/opt`
               then `source ~/opt/minc-toolkit-<version>/minc-toolkit-config.sh`.
-            - Every dependency the toolkit vendors (zlib, HDF5, netCDF, GSL, FFTW, JPEG, OpenJPEG, libarchive, OpenBLAS, ITK) is inside the tarball. Only glibc 2.35+ and, for the `full` variant, the system X11/OpenGL/GLFW runtime libraries are needed.
+            - Every dependency the toolkit vendors (zlib, HDF5, netCDF, GSL, FFTW, JPEG, OpenJPEG, libarchive, OpenBLAS, ITK) is inside the tarball. From the distribution it needs glibc 2.35+ and the GCC runtime libraries (`libstdc++`, `libgcc_s`, `libgfortran`, `libquadmath`, `libgomp`), plus the system X11/OpenGL/GLFW runtime libraries for the `full` variant.
             - Source the config script from **bash**: it locates the prefix through `BASH_SOURCE`, and other shells fall back to the path baked in at build time.
 
             **macOS** (Apple Silicon / arm64; built on macos-14 / 15 / 26 runners):

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -418,6 +418,13 @@ jobs:
           set -euxo pipefail
           VER="${{ needs.meta.outputs.version }}"
           DESTDIR="$PWD/pkgroot" cmake --build build --target install
+          # Strip the ELF objects. CPACK_STRIP_FILES only covers the CPack
+          # generators, so this tree would otherwise ship whatever debug info the
+          # build produced -- and the toolkit's own components compile with -g.
+          # Perl scripts, data and man pages are matched out by file(1).
+          find pkgroot -type f -exec file -N {} + 2>/dev/null \
+            | awk -F': ' '/ELF .*(executable|shared object)/ { print $1 }' \
+            | xargs -r strip --strip-unneeded 2>/dev/null || true
           # Repoint the top directory at a self-describing name: the tree unpacks
           # anywhere, so the /opt/minc/<ver> prefix it was configured with is only
           # a build-time detail.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -407,7 +407,6 @@ jobs:
             -DMT_BUILD_VISUAL_TOOLS=$FULL \
             -DMT_BUILD_OPENBLAS=ON \
             -DMT_USE_OPENMP=ON \
-            -DMT_BUILD_DCM2MNC_TESTS=ON \
             -DUSE_SYSTEM_ITK=OFF \
             .
           cmake --build build -j"$(nproc)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -342,6 +342,8 @@ jobs:
   # a system prefix. Passing no USE_SYSTEM_* flags leaves them at their OFF
   # default, so zlib, HDF5, netCDF, GSL, FFTW, JPEG, OpenJPEG, libarchive,
   # OpenBLAS and ITK are all built from source and shipped inside the tarball.
+  # `full` also builds every optional component: ANTs, C3D, Elastix, ABC and the
+  # visual tools.
   superbuild-tarball:
     needs: meta
     runs-on: ubuntu-latest
@@ -401,9 +403,11 @@ jobs:
             -DMT_BUILD_ANTS=$FULL \
             -DMT_BUILD_C3D=$FULL \
             -DMT_BUILD_ELASTIX=$FULL \
+            -DMT_BUILD_ABC=$FULL \
             -DMT_BUILD_VISUAL_TOOLS=$FULL \
             -DMT_BUILD_OPENBLAS=ON \
             -DMT_USE_OPENMP=ON \
+            -DMT_BUILD_DCM2MNC_TESTS=ON \
             -DUSE_SYSTEM_ITK=OFF \
             .
           cmake --build build -j"$(nproc)"
@@ -435,16 +439,13 @@ jobs:
       - name: Check the tarball actually relocates
         run: |
           set -euxo pipefail
-          # Unpack somewhere the build never mentioned. Sourcing the config script
-          # and writing a volume covers the whole chain the run paths have to carry:
-          # libminc -> HDF5 -> zlib (MINC_COMPRESS=4 puts the write through deflate).
+          # Unpack somewhere the build never mentioned and hand the tree to the
+          # check: the config script finds its own prefix, every shipped object
+          # resolves its libraries inside the tarball, every installed command
+          # starts, and the MINC, ITK and third-party tools do real work.
           mkdir -p /tmp/relocated
           tar xzf ./*.tar.gz -C /tmp/relocated
-          . /tmp/relocated/minc-toolkit-*/minc-toolkit-config.sh
-          # Same geometry as the mni_autoreg ellipse0 test; the defaults do not
-          # overlap a small volume.
-          make_phantom -clobber -ellipse -nelements 64 64 64 -step 2 2 2 -start -64 -64 -64 -center 0 0 0 /tmp/relocated/phantom.mnc
-          mincinfo /tmp/relocated/phantom.mnc
+          .github/scripts/check-relocation.sh /tmp/relocated/minc-toolkit-* '${{ matrix.variant }}'
       - uses: actions/upload-artifact@v7
         with:
           name: tarball-${{ matrix.variant }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -476,7 +476,7 @@ jobs:
             - Self-contained and relocatable — unpack it anywhere, no root needed:
               `tar xzf minc-toolkit-v2-<version>-<variant>-linux-x86_64.tar.gz -C ~/opt`
               then `source ~/opt/minc-toolkit-<version>/minc-toolkit-config.sh`.
-            - Every dependency the toolkit vendors (zlib, HDF5, netCDF, GSL, FFTW, JPEG, OpenJPEG, libarchive, OpenBLAS, ITK) is inside the tarball. From the distribution it needs glibc 2.35+ and the GCC runtime libraries (`libstdc++`, `libgcc_s`, `libgfortran`, `libquadmath`, `libgomp`), plus the system X11/OpenGL/GLFW runtime libraries for the `full` variant.
+            - Every dependency the toolkit vendors (zlib, HDF5, netCDF, GSL, FFTW, JPEG, OpenJPEG, libarchive, OpenBLAS, ITK) is inside the tarball. The `minimal` variant links five host libraries and nothing else — `libc`, `libm`, `libgcc_s`, `libstdc++`, `libgomp` — so it needs glibc 2.35+ and the GCC runtime; `full` adds the system X11/OpenGL/GLFW runtime libraries.
             - Source the config script from **bash**: it locates the prefix through `BASH_SOURCE`, and other shells fall back to the path baked in at build time.
 
             **macOS** (Apple Silicon / arm64; built on macos-14 / 15 / 26 runners):

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ sudo dnf install minc-toolkit-v2-<version>-fc<release>-<variant>.x86_64.rpm
 Install on macOS: open the `.pkg` file. The package is not signed. On the first
 run, right-click the file and select **Open** to get past Gatekeeper.
 
-Install on any other Linux, or without root, from the relocatable tarball:
+Install on any other x86_64 Linux, or without root, from the relocatable tarball:
 
 ```sh
 tar xzf minc-toolkit-v2-<version>-<variant>-linux-x86_64.tar.gz -C ~/opt
@@ -66,11 +66,12 @@ source ~/opt/minc-toolkit-<version>/minc-toolkit-config.sh
 ```
 
 This tarball carries its own zlib, HDF5, netCDF, GSL, FFTW, JPEG, OpenJPEG,
-libarchive, OpenBLAS and ITK, so it needs nothing from the distribution beyond
-glibc 2.35 or newer — and, for the `full` variant, the system X11, OpenGL and
-GLFW runtime libraries. Unpack it wherever you like; the binaries find their own
-libraries, and the config script finds the prefix through `BASH_SOURCE`, so
-source it from bash.
+libarchive, OpenBLAS and ITK. From the distribution it needs glibc 2.35 or newer
+and the GCC runtime libraries — `libstdc++` and `libgcc_s`, plus `libgfortran`,
+`libquadmath` and `libgomp` for OpenBLAS and OpenMP — and, for the `full`
+variant, the system X11, OpenGL and GLFW runtime libraries. Unpack it wherever
+you like and source the config script from bash: it finds the prefix through
+`BASH_SOURCE` and puts the tarball's own `lib` directory on `LD_LIBRARY_PATH`.
 
 The `.deb`, `.rpm` and `.pkg` packages install into `/opt/minc/<version>`. After
 you install, read [Set up your shell](#set-up-your-shell).

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ builds them for each `v<major>.<minor>.<patch>` tag:
 | Ubuntu 22.04, 24.04, 26.04 and Debian 11, 12, 13 | `minc-toolkit-v2_<version>_<distro>-<codename>-<variant>_amd64.deb` |
 | Fedora 42, 43, 44 | `minc-toolkit-v2-<version>-fc<release>-<variant>.x86_64.rpm` |
 | macOS on Apple Silicon | `minc-toolkit-v2-<version>-<runner>-arm64-<variant>.pkg` |
+| Any Linux x86_64 with glibc 2.35 or newer | `minc-toolkit-v2-<version>-<variant>-linux-x86_64.tar.gz` (relocatable, no root) |
 | Any | `minc-toolkit-v2-<version>-src.tar.gz` (source, submodules included) |
 
 Each platform has two variants:
@@ -57,8 +58,22 @@ sudo dnf install minc-toolkit-v2-<version>-fc<release>-<variant>.x86_64.rpm
 Install on macOS: open the `.pkg` file. The package is not signed. On the first
 run, right-click the file and select **Open** to get past Gatekeeper.
 
-Packages install into `/opt/minc/<version>`. After you install, read
-[Set up your shell](#set-up-your-shell).
+Install on any other Linux, or without root, from the relocatable tarball:
+
+```sh
+tar xzf minc-toolkit-v2-<version>-<variant>-linux-x86_64.tar.gz -C ~/opt
+source ~/opt/minc-toolkit-<version>/minc-toolkit-config.sh
+```
+
+This tarball carries its own zlib, HDF5, netCDF, GSL, FFTW, JPEG, OpenJPEG,
+libarchive, OpenBLAS and ITK, so it needs nothing from the distribution beyond
+glibc 2.35 or newer — and, for the `full` variant, the system X11, OpenGL and
+GLFW runtime libraries. Unpack it wherever you like; the binaries find their own
+libraries, and the config script finds the prefix through `BASH_SOURCE`, so
+source it from bash.
+
+The `.deb`, `.rpm` and `.pkg` packages install into `/opt/minc/<version>`. After
+you install, read [Set up your shell](#set-up-your-shell).
 
 Releases up to 1.9.18.3 carry only a source tarball. The binary packages listed
 above come from the current release workflow.
@@ -250,9 +265,10 @@ and a copy the superbuild downloads and builds. `ON` uses the system copy.
 | `USE_SYSTEM_PNG` | `ON` on Apple Silicon, `OFF` elsewhere |
 
 Building everything from source gives the most repeatable result and is the
-right choice for a personal install. The release packages use the system
-libraries instead, so that the resulting `.deb` and `.rpm` files depend on the
-distribution packages.
+right choice for a personal install. The `.deb` and `.rpm` packages use the
+system libraries instead, so that they depend on the distribution packages; the
+relocatable Linux tarball is built the other way, with every option above left
+at its `OFF` default.
 
 `USE_SYSTEM_NIFTI` works alongside the ITK tools, but only as of the ITK pinned
 in `cmake-modules/BuildITKv4.cmake`. ITK bundles its own NIfTI, and until

--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ source ~/opt/minc-toolkit-<version>/minc-toolkit-config.sh
 ```
 
 This tarball carries its own zlib, HDF5, netCDF, GSL, FFTW, JPEG, OpenJPEG,
-libarchive, OpenBLAS and ITK. From the distribution it needs glibc 2.35 or newer
-and the GCC runtime libraries — `libstdc++` and `libgcc_s`, plus `libgfortran`,
-`libquadmath` and `libgomp` for OpenBLAS and OpenMP — and, for the `full`
-variant, the system X11, OpenGL and GLFW runtime libraries. Unpack it wherever
-you like and source the config script from bash: it finds the prefix through
+libarchive, OpenBLAS and ITK. The `minimal` variant links five host libraries
+and nothing else: `libc`, `libm`, `libgcc_s`, `libstdc++` and `libgomp`, so it
+needs glibc 2.35 or newer and the GCC runtime. `full` adds the system X11,
+OpenGL and GLFW runtime libraries for the visual tools. Unpack it wherever you
+like and source the config script from bash: it finds the prefix through
 `BASH_SOURCE` and puts the tarball's own `lib` directory on `LD_LIBRARY_PATH`.
 
 The `.deb`, `.rpm` and `.pkg` packages install into `/opt/minc/<version>`. After

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ and nothing else: `libc`, `libm`, `libgcc_s`, `libstdc++` and `libgomp`, so it
 needs glibc 2.35 or newer and the GCC runtime. `full` adds the system X11,
 OpenGL and GLFW runtime libraries for the visual tools. Unpack it wherever you
 like and source the config script from bash: it finds the prefix through
-`BASH_SOURCE` and puts the tarball's own `lib` directory on `LD_LIBRARY_PATH`.
+`BASH_SOURCE`.
 
 The `.deb`, `.rpm` and `.pkg` packages install into `/opt/minc/<version>`. After
 you install, read [Set up your shell](#set-up-your-shell).


### PR DESCRIPTION
Split out of the original #233, which also carried a dependency bump. The bump is now #233 on its own; this PR is the CI change alone. The two touch disjoint files and can merge in either order.

## The gap

**No Linux job builds the vendored path.** Every Linux job in `ci.yml` and `release.yml` sets nine `USE_SYSTEM_*` options to ON, so zlib, HDF5, netCDF, GSL, FFTW, JPEG, OpenJPEG and libarchive come from the distribution. The `Build*.cmake` modules for them are only ever exercised on **macOS** — the one platform whose jobs pass no `USE_SYSTEM_*` flags at all. A stale or broken vendored dependency can sit unnoticed on Linux indefinitely, and that is exactly how the versions in #233 got as old as they did.

## What this adds

A `superbuild` job in `ci.yml` and a `superbuild-tarball` job in `release.yml` that pass none of those flags, so zlib, HDF5, netCDF, GSL, FFTW, JPEG, OpenJPEG, libarchive, OpenBLAS and ITK all build from source. `minimal` and `full`, Linux x86_64. Each runs ctest and packages a relocatable tarball — useful in its own right for anyone not on a distro this workflow packages for, or who cannot install to a system prefix.

`full` builds every component the tree can: ANTs, C3D, Elastix, the visual tools and **ABC**, which no job has ever built.

`MT_BUILD_DCM2MNC_TESTS` was in here too and is now out. It needs CMake 3.24 for `DOWNLOAD_EXTRACT_TIMESTAMP`, and 22.04 has 3.22, where the argument survives into the generated extract script and kills the download step. minctools declares `CMAKE_MINIMUM_REQUIRED 3.10`, so that breaks the option on every CMake from 3.10 to 3.23, not only here — BIC-MNI/minc-tools#128 guards it, and the option can come back once that pin bumps.

Choices worth arguing about:

- **`ubuntu:22.04`, not 24.04.** The artifact has to run somewhere other than the machine that built it, so it wants the oldest glibc still carrying a CMake new enough for everything the superbuild vendors. 22.04 gives glibc 2.35 and CMake 3.22, and 22.04 is the oldest release this project intends to support.
- **No `-dev` package for anything the superbuild vendors**, so nothing can quietly fall back to a system copy and escape the tarball. The `full` variant still installs the X11/OpenGL/GLFW dev packages — bicgl links the system GLFW and there is no vendored windowing stack, same as the `.deb`.
- **DESTDIR install with the top directory repointed** to `minc-toolkit-<version>`, so the tarball unpacks anywhere instead of reproducing `/opt/minc/<version>`. `cpack -G TGZ` would have shipped the `opt/minc/...` path prefix.

## The relocation check

`.github/scripts/check-relocation.sh`, called from both workflows with the unpacked prefix and the variant. It unpacks the tarball somewhere the build never named and then:

1. **The config script reports the unpacked prefix**, not the configure-time one, and exports `MINC_COMPRESS=4`.
2. **Every shipped ELF object resolves its libraries.** Anything unresolved fails. So does anything resolved outside the tarball and outside the system library directories — that is how a run path into the superbuild staging tree would show up. So does a system copy of a library the tarball itself ships — that is how a vendored build escaping into the distribution's libraries would show up. The host libraries it does use are printed: that list is the tarball's real external dependency set, and README quotes it.
3. **Every installed command in `bin/` and `pipeline/` starts.** Usage messages and non-zero exits are expected and ignored; the loader or the perl interpreter giving up is not.
4. **Core MINC tools do real work**: `make_phantom`, `minccalc`, `mincresample`, `mincblur`, `mincstats`. `MINC_COMPRESS=4` comes from the config script, so the same volume is also written with compression off and the sizes compared — that shows the deflate filter really ran rather than assuming it from the variable.
5. **The ITK-based MINC tools do real work**: `itk_resample`, `itk_morph`, `itk_distance`, `itk_convert` (NIfTI IO) and `minc_anlm`.
6. **The bundled third-party commands**, on `full`: ANTs (`N4BiasFieldCorrection`, `antsApplyTransforms`, `ImageMath`), C3D, and the Elastix and transformix version banners. Elastix needs a parameter file and ABC needs an atlas directory, and the visual tools need a display, so those are covered by step 3 alone — but every one of them is asserted present, so a tool missing from the `full` tarball is red rather than quietly skipped.

Step 3 reports perl scripts that cannot find a module without failing on the six already in that state: `normalize_mri`, `smooth_mask` and `lgmask` want `ctime.pl`, removed from perl core in **5.16** (2012), and `xfmdecomp.pl`, `patch_segmentation_pipeline.pl` and `ana2mnc_xfm_reduce.pl` want CPAN modules. The `.deb` and `.rpm` declare only `perl`, so this is not specific to the tarball and not a relocation defect. All of it is now fixed elsewhere: BIC-MNI/inormalize#5 and BIC-MNI/conglomerate#7 for `ctime.pl`, #238 for the two CPAN modules. A sixth script would fail the job.

`README.md` and the release notes gain the tarball, with two caveats stated in both: the config script locates the prefix through `BASH_SOURCE`, so source it from bash; and the tarball needs the GCC runtime libraries from the host, not glibc alone, because OpenBLAS is built with gfortran and the build sets `MT_USE_OPENMP=ON`.

## Evidence

Both superbuild jobs, as originally written, ran green **on this PR** at 369c9e2 ([run 33705141672](https://github.com/gdevenyi/minc-toolkit-v2/actions/runs/33705141672)) — `Configure + build`, `Run test suite`, `Build tarball` and the relocation check all passed for `minimal` and `full`. So the vendored path does build on Linux with the currently pinned HDF5 1.12.1 and netCDF 4.7.4; it needed no help from #233. `superbuild (full)` builds ANTs, C3D, Elastix, the visual tools and every vendored library including OpenBLAS from source in roughly 70 minutes, producing a 276 MB tarball.

The two red jobs on that run are `macos (minimal)` and `macos (full)`, both failing in ctest. They fail the same way on `develop-1.9.18` itself at cc2cf7f, this PR's merge base ([run 32898811129](https://github.com/BIC-MNI/minc-toolkit-v2/actions/runs/32898811129)), and this PR adds no macOS job and touches no macOS file.

**Both superbuild jobs are now green with the whole check running** ([run 33984705682](https://github.com/gdevenyi/minc-toolkit-v2/actions/runs/33984705682)). ABC compiled against the pinned ITK 4.14 and ships `ABC_MINC` — a first for this tree. The check reported:

| | `minimal` | `full` |
| --- | --- | --- |
| ELF objects linkage-checked | 479 | 587 |
| Commands started | 523 | 653 |
| Host libraries linked | 5 | 16 |

The `minimal` tarball links `libc`, `libm`, `libgcc_s`, `libstdc++` and `libgomp`, and nothing else. `full` adds the X11, OpenGL and GLFW stack. `libgfortran` and `libquadmath` never appear, so README and the release notes now state the measured list instead of an estimate. `N4BiasFieldCorrection`, `antsApplyTransforms`, `ImageMath` and `c3d` all did real work on the phantom; `elastix version: 4.801`.

Two things that run exposed, both fixed here:

- Step 3 hit `xrealloc: cannot allocate 18446744071944188288 bytes` twice on the `full` tarball — two commands write enough in 20 seconds to exhaust bash's command-substitution buffer. The capture is now capped at 64 KB, which also stops those two early instead of at the timeout.
- The perl report lists four scripts. `lgmask` is absent from it because it dies compiling on `defined(@array)` before it reaches its `ctime.pl` line — that, and a missing `:geometry` import that only surfaced once it compiled, are fixed in BIC-MNI/inormalize#5.

## Known fragility, not introduced here

These builds download HDF5, netCDF, GSL, FFTW, libarchive and now ABC at build time, and `macos (minimal)` on `develop-1.9.18` has failed purely because `libarchive.org` returned a 504. `MT_PACKAGES_PATH` plus `actions/cache` would make those cacheable; happy to add it here or separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5NQ3wnC2yygmxWeM5NxNm
