### PR TITLE
Adopt the distributions' baseline hardening flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,84 @@ IF(APPLE)
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES -D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION")
 ENDIF()
 
+# ---------------------------------------------------------------------------
+# Default build flags for the in-tree components
+#
+# CMake's Release default is -O3, with no debug info and no hardening. Every
+# distribution this project packages for has shipped -O2 -g plus a baseline of
+# hardening flags for years; the toolkit never picked any of it up, because the
+# .deb and .rpm are produced by CPack rather than by dpkg-buildflags or
+# rpmbuild, so the distribution flags never reach the compiler.
+#
+# Measured defaults, for the record:
+#   Debian 11/12/13   -O2 -g -fstack-protector-strong -D_FORTIFY_SOURCE=2
+#                     -Wformat -Werror=format-security, ld -Wl,-z,relro
+#   Ubuntu 22.04+     as Debian, plus LTO; 24.04+ adds _FORTIFY_SOURCE=3,
+#                     -fstack-clash-protection, -fcf-protection, frame pointers
+#   Fedora 42+        as above, plus -D_GLIBCXX_ASSERTIONS, full RELRO
+#                     (-Wl,-z,relro -Wl,-z,now) and -march=x86-64 -mtune=generic
+#   Homebrew          -Os for clang, -O2 for gcc, no hardening, no -march
+#
+# Take the hardening the distributions have shipped since Debian 11, and the
+# debug info that goes with it. Keep CMake's -O3.
+#
+# The optimisation level is deliberately NOT lowered to -O2, even though every
+# distribution ships -O2. Benchmarked on the ICBM152 2009c template, -O2 costs
+# 6.6% across the toolkit and 43% on `mincresample -tricubic`, for output that
+# is bit-identical. The entire 43% comes from one optimisation, -fipa-cp-clone,
+# which -O3 enables and -O2 does not. Distributions choose -O2 to balance build
+# time and code size across tens of thousands of packages; that trade does not
+# apply to a compute toolkit.
+#
+# The hardening below measures at 0.3% over the same workload set, which is why
+# it is on by default.
+#
+# Deliberately left out:
+#   -Werror=format-security      this code has never been compiled with it and
+#                                would fail rather than warn -- its own change
+#   -flto=auto                   costly across ITK/ANTs, a known breakage source
+#   -D_GLIBCXX_ASSERTIONS        real cost in imaging inner loops
+#   -Wl,-z,pack-relative-relocs  needs glibc >= 2.36 at run time, and the
+#                                relocatable tarball targets glibc 2.35
+#   -Wl,-Bsymbolic-functions     Ubuntu-specific; changes interposition
+#   -march= / -mtune=            -march=x86-64 -mtune=generic is already the
+#                                compiler default on x86-64, and OpenBLAS -- the
+#                                one component where the choice has teeth --
+#                                already builds DYNAMIC_ARCH and dispatches on
+#                                the CPU at run time
+#
+# add_compile_options()/link_libraries() rather than CMAKE_C_FLAGS: these reach
+# the ADD_SUBDIRECTORY() components below but are not part of
+# CMAKE_EXTERNAL_PROJECT_ARGS, so the vendored ExternalProjects (ITK, ANTs,
+# C3D, Elastix, HDF5, netCDF, ...) keep their own defaults. link_libraries()
+# rather than add_link_options() because the latter needs CMake 3.13 and this
+# project still declares 3.10.
+# ---------------------------------------------------------------------------
+OPTION(MT_USE_DEFAULT_FLAGS "Apply the toolkit's default hardening flags and debug info to its own components. Turn OFF to drive the compiler entirely from CMAKE_C_FLAGS/CMAKE_CXX_FLAGS." ON)
+
+IF(MT_USE_DEFAULT_FLAGS AND NOT MSVC)
+  # Debug info only: the optimisation level is left to the build type, so a
+  # Release build keeps CMake's -O3. -g changes no generated code, only the
+  # sections the linker emits, and CPACK_STRIP_FILES drops them again from the
+  # .deb/.rpm/.pkg.
+  add_compile_options($<$<CONFIG:Release>:-g>)
+
+  add_compile_options(-fstack-protector-strong)
+
+  # _FORTIFY_SOURCE does nothing without optimisation and warns at -O0, so key
+  # it to the optimised configurations. -U first because some toolchains (Arch,
+  # Gentoo) predefine it and redefining warns; Fedora's own flags do the same.
+  add_compile_options(
+    $<$<NOT:$<CONFIG:Debug>>:-U_FORTIFY_SOURCE>
+    $<$<NOT:$<CONFIG:Debug>>:-D_FORTIFY_SOURCE=2>)
+
+  # Mach-O has no -z options and ld64 errors on them, so full RELRO is
+  # Linux-only. macOS keeps the stack protector above.
+  IF(UNIX AND NOT APPLE)
+    link_libraries(-Wl,-z,relro -Wl,-z,now)
+  ENDIF()
+ENDIF()
+
 SET(CPACK_PACKAGE_FILE_NAME "minc-toolkit-${MINC_TOOLKIT_VERSION_FULL}-${MT_SYSTEM_NAME}")
 
 # register local modules

--- a/README.md
+++ b/README.md
@@ -211,6 +211,37 @@ Pass these to `cmake` as `-D<option>=ON` or `-D<option>=OFF`.
 `MT_BUILD_ANTS`, `MT_BUILD_C3D`, `MT_BUILD_ELASTIX`, and `MT_BUILD_ABC` only
 appear in the CMake cache after `MT_BUILD_ITK_TOOLS` is on.
 
+### Compiler flags
+
+| Option | Default | Effect |
+| --- | --- | --- |
+| `MT_USE_DEFAULT_FLAGS` | `ON` | Apply the default hardening flags below. `OFF` leaves the compiler entirely to `CMAKE_C_FLAGS` / `CMAKE_CXX_FLAGS`. |
+
+A `Release` build of the toolkit's own components compiles with:
+
+| Flag | Why |
+| --- | --- |
+| `-g` | Debug info, as every distribution ships. Changes no generated code; `CPACK_STRIP_FILES` removes it from the packages. The optimisation level is left alone, so `Release` keeps CMake's `-O3`. |
+| `-fstack-protector-strong` | Stack smashing detection. Every supported distribution enables it. |
+| `-D_FORTIFY_SOURCE=2` | Compile-time and run-time checks on the string and memory functions. Skipped in `Debug`, where it does nothing. |
+| `-Wl,-z,relro -Wl,-z,now` | Full RELRO. Linux only; Mach-O has no equivalent. |
+
+These reach the components built from this repository. The vendored
+third-party projects — ITK, ANTs, Convert3D, Elastix, HDF5, netCDF, OpenBLAS
+and the rest — keep their own defaults, because they are configured as separate
+CMake projects. Set `MT_USE_DEFAULT_FLAGS=OFF` to drive the compiler entirely
+yourself, for example to build with `-march=native`.
+
+Not enabled, and why: `-O2` (every distribution ships it, but it costs 6.6%
+across the toolkit and 43% on `mincresample -tricubic` for bit-identical output
+— the whole difference is `-fipa-cp-clone`, which `-O3` enables and `-O2` does
+not), `-Werror=format-security` (every distribution sets it, but this code has
+never compiled under it), link-time optimisation (costly and a known source of
+breakage across ITK and ANTs), `-D_GLIBCXX_ASSERTIONS` (bounds checking in
+imaging inner loops), and `-march=`/`-mtune=` (the x86-64 baseline is already
+the compiler default, and OpenBLAS — where the choice actually has teeth —
+builds with `DYNAMIC_ARCH` and selects its kernels from CPUID at run time).
+
 ### Windowing backend
 
 | Option | Default | Effect |


### PR DESCRIPTION
Independent of #233 and #234, though it has one interaction with #234 noted at the bottom.

> **Updated.** This PR originally moved the toolkit to `-O2 -g` as well. Benchmarking
> (see [the comment below](#issuecomment-5535429466)) showed the hardening costs 0.3% but `-O2`
> costs 43% on `mincresample -tricubic`, for bit-identical output. The `-O2` change has been
> dropped; `Release` keeps CMake's `-O3`.

## The gap

CMake's `Release` default is `-O3`, no debug info, no hardening — and that is all this
project has ever compiled with. The `.deb` and `.rpm` come out of **CPack, not
`dpkg-buildflags` or `rpmbuild`**, so the distribution flags never reach the compiler. This
toolkit has never been built with a single distro hardening flag.

## What the targets actually use

Measured in containers, not recalled:

| Target | Opt | Debug | Hardening | LTO | arch |
| --- | --- | --- | --- | --- | --- |
| **this toolkit, today** | `-O3` | — | **none** | no | — |
| Debian 11 / 12 | `-O2` | `-g` | ssp-strong, `_FORTIFY_SOURCE=2`, `-Werror=format-security`, relro | no | — |
| Debian 13 | `-O2` | `-g` | + stack-clash, cf-protection | no | — |
| Ubuntu 22.04 | `-O2` | `-g` | ssp-strong, FORTIFY=2, format-security, relro | yes | — |
| Ubuntu 24.04 / 26.04 | `-O2` | `-g` | + stack-clash, cf-protection, FORTIFY=3, frame pointers | yes | — |
| Fedora 42 / 44 | `-O2` | `-g` | FORTIFY=3, `_GLIBCXX_ASSERTIONS`, ssp-strong, stack-clash, cf-protection, hardened specs | yes | `-m64 -march=x86-64 -mtune=generic` |
| Homebrew | `-Os` (clang) | — | none | no | none |

## What this takes

The hardening present since Debian 11, plus the debug info:

```
-g  -fstack-protector-strong  -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
-Wl,-z,relro -Wl,-z,now        # Linux only; Mach-O has no -z options
```

`-U` before `-D` is Fedora's own trick, so toolchains that predefine `_FORTIFY_SOURCE`
(Arch, Gentoo) don't warn on redefinition.

## Why not `-O2`, when every distribution ships it

Because it was measured. Four builds of this branch — `{-O3, -O2} x {plain, hardened}` —
same sources, same pre-built external libraries, on the ICBM152 2009c template, pinned to
one core, 10 reps interleaved. Median user+sys CPU:

| | hardening, at fixed `-O` | `-O3` → `-O2` |
| --- | ---: | ---: |
| whole workload set | **+0.3%** | **+6.6%** |
| `mincresample -tricubic` | +0.6% | **+43.0%** |

All four builds produce **bit-identical** output. The 43% buys nothing, and it resolves the
old "risk to watch in CI" note in this description: there is no numerical shift, because
there is no numerical change.

The entire 43% comes from one optimisation, `-fipa-cp-clone`, which `-O3` enables and `-O2`
does not. `-O2 -fipa-cp-clone` matches `-O3` exactly; `-O2 -ftree-vectorize` recovers none
of it (GCC 12+ already vectorises at `-O2`). Distributions pick `-O2` to balance build time
and code size across tens of thousands of packages, which is not the trade-off a compute
toolkit wants.

So the optimisation level is left alone. `Release` keeps `-O3`.

## What it deliberately leaves out

| Flag | Why not |
| --- | --- |
| `-O2` | Costs 6.6% overall and 43% on tricubic resampling, for identical output. See above. |
| `-Werror=format-security` | Every distribution sets it; this code has never compiled under it and would **fail rather than warn**. Its own change. |
| `-flto=auto -ffat-lto-objects` | Costly across ITK and ANTs, and a known breakage source. |
| `-D_GLIBCXX_ASSERTIONS` | Bounds-checks libstdc++ containers in imaging inner loops. |
| `-Wl,-z,pack-relative-relocs` | Needs **glibc ≥ 2.36** at run time. The relocatable tarball in #234 targets glibc 2.35 on `ubuntu:22.04`, so this would silently break it. |
| `-Wl,-Bsymbolic-functions` | Ubuntu-specific; changes symbol interposition semantics. |
| `-Wl,--as-needed` | Good hygiene, but link-order-sensitive in a codebase this old. Deserves its own PR. |
| `-march=` / `-mtune=` | `-march=x86-64 -mtune=generic` is *already* the compiler default on x86-64, so copying Fedora changes no codegen — and invites someone to later "modernise" it to `x86-64-v2` and silently drop old hardware. OpenBLAS, the one component where the choice has teeth, already builds `DYNAMIC_ARCH` and dispatches on CPUID at run time. |

## Scope: in-tree components only

Applied via `add_compile_options()` / `link_libraries()` rather than `CMAKE_C_FLAGS`, so
they reach the `ADD_SUBDIRECTORY()` components but are **not** part of
`CMAKE_EXTERNAL_PROJECT_ARGS`. ITK, ANTs, Convert3D, Elastix, HDF5, netCDF and OpenBLAS keep
their own defaults. Known limitation: the vendored half is most of the shipped bytes and
stays unhardened — worth extending once the in-tree half has proven itself.

`link_libraries()` rather than `add_link_options()` because the latter wants CMake 3.13
while this project declares 3.10, and raising the minimum would flip every policy up to
3.13 — CMP0077 among them — across two dozen subprojects. Not a side effect worth taking
for two link flags.

## New option

`MT_USE_DEFAULT_FLAGS=OFF` turns the whole block off, for anyone who wants to drive the
compiler entirely from `CMAKE_C_FLAGS` / `CMAKE_CXX_FLAGS`.

## Verified

Configured from this branch:

- `Release` → `-O3 -DNDEBUG -g -fstack-protector-strong -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2`, linking `-Wl,-z,relro -Wl,-z,now`.
- `Debug` → `-g -fstack-protector-strong`, no `_FORTIFY_SOURCE` (which does nothing unoptimised and warns at `-O0`).
- `MT_USE_DEFAULT_FLAGS=OFF` → adds nothing at all.
- The resulting executables **and `libminc2.so`** carry `GNU_RELRO`, `BIND_NOW` and `__stack_chk_fail`.

## Interaction with #234

`-g` only makes sense if the artifacts get stripped. `CPACK_STRIP_FILES` already covers the
`.deb`/`.rpm`/`.pkg`, but the tarball job in #234 is a plain `DESTDIR` install — so a strip
step has been added there. If #234 lands first the strip is a no-op that merely shrinks
today's 276 MB tarball; if this lands first the tarball grows until #234 follows. Measured:
`-g` makes the unstripped install tree about 3.5x larger, while the stripped size is
unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BSJEuG4trwXNQ6x6h2raX
