### PR TITLE
Declare the two CPAN modules the installed perl scripts need

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,20 @@ until you supply it.
   [BEaST_library](https://github.com/BIC-MNI/BEaST_library). See `BEaST/README`
   for the file layout the library must have.
 
+### Perl modules that are not included
+
+Two installed scripts need a module from CPAN. Every other program works
+without them.
+
+| Script | Module | Debian and Ubuntu | Fedora |
+| --- | --- | --- | --- |
+| `xfmdecomp.pl` | `Math::MatrixReal` | `libmath-matrixreal-perl` | `perl-Math-MatrixReal` |
+| `patch_segmentation_pipeline.pl` | `Parallel::ForkManager` | `libparallel-forkmanager-perl` | `perl-Parallel-ForkManager` |
+
+The `.deb` recommends both packages and the `.rpm` suggests them, so a normal
+`apt` or `dnf` install pulls them in. Install them yourself if you use the
+relocatable tarball, or build from source.
+
 ## Bundled packages
 
 Core MINC packages, all built by default:

--- a/README.md
+++ b/README.md
@@ -452,17 +452,20 @@ until you supply it.
 
 ### Perl modules that are not included
 
-Two installed scripts need a module from CPAN. Every other program works
-without them.
+Two installed scripts need CPAN modules. Every other program works without
+them.
 
 | Script | Module | Debian and Ubuntu | Fedora |
 | --- | --- | --- | --- |
 | `xfmdecomp.pl` | `Math::MatrixReal` | `libmath-matrixreal-perl` | `perl-Math-MatrixReal` |
 | `patch_segmentation_pipeline.pl` | `Parallel::ForkManager` | `libparallel-forkmanager-perl` | `perl-Parallel-ForkManager` |
 
-The `.deb` recommends both packages and the `.rpm` suggests them, so a normal
-`apt` or `dnf` install pulls them in. Install them yourself if you use the
-relocatable tarball, or build from source.
+The `.deb` lists both as `Recommends`, so `apt` installs them unless you tell it
+not to. The `.rpm` lists them weakly too, but `dnf` installs only `Recommends`
+automatically, and Fedora 42 and 43 build with a CMake too old to emit that, so
+they get `Suggests`, which `dnf` shows and does not install. Install the two
+packages by hand there, and if you use the relocatable tarball or build from
+source.
 
 ## Bundled packages
 

--- a/cmake-modules/DebianPackageAddons.cmake
+++ b/cmake-modules/DebianPackageAddons.cmake
@@ -8,7 +8,7 @@
 SET(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 SET(CPACK_DEBIAN_PACKAGE_GENERATE_SHLIBS ON)
 SET(CPACK_DEBIAN_PACKAGE_DEPENDS "perl, imagemagick")
-# Two scripts out of the several hundred installed need a CPAN module:
+# Two scripts out of the several hundred installed need CPAN modules:
 # xfmdecomp.pl needs Math::MatrixReal, patch_segmentation_pipeline.pl needs
 # Parallel::ForkManager. Everything else works without them, so these are
 # Recommends rather than Depends -- apt installs them by default, and the

--- a/cmake-modules/DebianPackageAddons.cmake
+++ b/cmake-modules/DebianPackageAddons.cmake
@@ -8,5 +8,11 @@
 SET(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 SET(CPACK_DEBIAN_PACKAGE_GENERATE_SHLIBS ON)
 SET(CPACK_DEBIAN_PACKAGE_DEPENDS "perl, imagemagick")
+# Two scripts out of the several hundred installed need a CPAN module:
+# xfmdecomp.pl needs Math::MatrixReal, patch_segmentation_pipeline.pl needs
+# Parallel::ForkManager. Everything else works without them, so these are
+# Recommends rather than Depends -- apt installs them by default, and the
+# package stays installable where they are not available.
+SET(CPACK_DEBIAN_PACKAGE_RECOMMENDS "libmath-matrixreal-perl, libparallel-forkmanager-perl")
 SET(CPACK_DEBIAN_PACKAGE_SECTION "science")
 SET(CPACK_DEBIAN_PACKAGE_PRIORITY "optional")

--- a/cmake-modules/RPMPackageAddons.cmake
+++ b/cmake-modules/RPMPackageAddons.cmake
@@ -8,5 +8,13 @@
 SET(CPACK_RPM_PACKAGE_GROUP "Applications/Engineering")
 SET(CPACK_RPM_PACKAGE_AUTOREQPROV "yes")
 SET(CPACK_RPM_PACKAGE_REQUIRES "perl, ImageMagick")
+# See DebianPackageAddons.cmake: the same two scripts, as a weak dependency.
+# rpmbuild's perl generator probably already emits these as hard Requires,
+# since AUTOREQPROV is on and both scripts are executable with a perl shebang;
+# stating them weakly covers the case where it does not, and a Suggests cannot
+# make the package harder to install either way. CPACK_RPM_PACKAGE_RECOMMENDS
+# would be the closer match, but it needs CMake 4.1, newer than the Fedora
+# images this workflow builds on.
+SET(CPACK_RPM_PACKAGE_SUGGESTS "perl-Math-MatrixReal, perl-Parallel-ForkManager")
 SET(CPACK_RPM_PACKAGE_RELOCATABLE OFF)
 SET(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/opt")

--- a/cmake-modules/RPMPackageAddons.cmake
+++ b/cmake-modules/RPMPackageAddons.cmake
@@ -8,13 +8,22 @@
 SET(CPACK_RPM_PACKAGE_GROUP "Applications/Engineering")
 SET(CPACK_RPM_PACKAGE_AUTOREQPROV "yes")
 SET(CPACK_RPM_PACKAGE_REQUIRES "perl, ImageMagick")
-# See DebianPackageAddons.cmake: the same two scripts, as a weak dependency.
-# rpmbuild's perl generator probably already emits these as hard Requires,
-# since AUTOREQPROV is on and both scripts are executable with a perl shebang;
-# stating them weakly covers the case where it does not, and a Suggests cannot
-# make the package harder to install either way. CPACK_RPM_PACKAGE_RECOMMENDS
-# would be the closer match, but it needs CMake 4.1, newer than the Fedora
-# images this workflow builds on.
-SET(CPACK_RPM_PACKAGE_SUGGESTS "perl-Math-MatrixReal, perl-Parallel-ForkManager")
+# See DebianPackageAddons.cmake: the same two scripts, weakly.
+#
+# dnf's install_weak_deps default pulls in Recommends and Supplements, never
+# Suggests, so Recommends is the one that actually reaches the user. CPack only
+# gained CPACK_RPM_PACKAGE_RECOMMENDS in CMake 4.1: Fedora 44 has 4.3 and gets
+# it, Fedora 42 and 43 have 3.31 and fall back to Suggests, which dnf shows but
+# does not install. An older CPack ignores the variable it does not know, so the
+# version test is what keeps the fallback honest rather than silent.
+#
+# rpmbuild's perl generator may already emit both as hard Requires, since
+# AUTOREQPROV is on and both scripts are executable with a perl shebang. A weak
+# declaration cannot make the package harder to install either way.
+IF(CMAKE_VERSION VERSION_GREATER_EQUAL 4.1)
+  SET(CPACK_RPM_PACKAGE_RECOMMENDS "perl-Math-MatrixReal, perl-Parallel-ForkManager")
+ELSE()
+  SET(CPACK_RPM_PACKAGE_SUGGESTS "perl-Math-MatrixReal, perl-Parallel-ForkManager")
+ENDIF()
 SET(CPACK_RPM_PACKAGE_RELOCATABLE OFF)
 SET(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/opt")


### PR DESCRIPTION
Running every installed command in the relocatable tarball (#234) found five perl scripts that die before they do any work. Three were `ctime.pl`, fixed upstream in BIC-MNI/inormalize#5 and BIC-MNI/conglomerate#7. The other two are this PR: they need a module from CPAN that nothing declares and nothing ships.

```
$ xfmdecomp.pl
Can't locate Math/MatrixReal.pm in @INC (you may need to install the Math::MatrixReal module) ...

$ patch_segmentation_pipeline.pl
Can't locate Parallel/ForkManager.pm in @INC (you may need to install the Parallel::ForkManager module) ...
```

`CPACK_DEBIAN_PACKAGE_DEPENDS` and `CPACK_RPM_PACKAGE_REQUIRES` list only `perl, imagemagick`, so a `.deb` or `.rpm` install leaves both scripts dead with no hint of why.

## Weak dependencies, not hard ones

Two scripts out of the several hundred installed need these, and the package is worth installing without them — so `Recommends` on the Debian side, which apt honours by default, and `Suggests` on the RPM side.

| Module | Debian and Ubuntu | Fedora |
| --- | --- | --- |
| `Math::MatrixReal` | `libmath-matrixreal-perl` | `perl-Math-MatrixReal` |
| `Parallel::ForkManager` | `libparallel-forkmanager-perl` | `perl-Parallel-ForkManager` |

`libmath-matrixreal-perl` is in `universe` on Ubuntu, which is a second reason not to make it a hard `Depends`.

`CPACK_RPM_PACKAGE_RECOMMENDS` would be the closer match on the RPM side, but it needs CMake 4.1 — newer than the Fedora images the release workflow builds on. Worth noting: `AUTOREQPROV` is on and both scripts are executable with a perl shebang, so rpmbuild's perl generator probably already emits these as hard `Requires`. If so the `Suggests` is redundant on Fedora and does no harm; if not, it is the only declaration there is. Someone should check `rpm -qR` on the next release build.

## README

The module and package names go next to **Data files that are not included**, since anyone using the relocatable tarball or building from source has to install them by hand.

## Not covered

`minctools/conversion/ana2mnc/ana2mnc_xfm_reduce.pl` also needs `Math::MatrixReal`, and `minctools/conversion/mri_to_minc/mri_to_minc.pl` has a `defined(@array)` that perl 5.22 made fatal. Neither directory is referenced by `minctools/conversion/CMakeLists.txt`, so neither script is built or installed and nothing here reaches them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5NQ3wnC2yygmxWeM5NxNm